### PR TITLE
fix(rtk-leave-meeting): use consistent primary button in leave dialog

### DIFF
--- a/packages/core/src/components/rtk-leave-meeting/rtk-leave-meeting.tsx
+++ b/packages/core/src/components/rtk-leave-meeting/rtk-leave-meeting.tsx
@@ -139,20 +139,16 @@ export class RtkLeaveMeeting {
                 {this.t('breakout_rooms.leave_confirmation.main_room_btn')}
               </rtk-button>
             )}
-            <rtk-button
-              variant={this.canEndMeeting ? 'secondary' : 'danger'}
-              title={this.t('leave')}
-              onClick={this.handleLeave}
-              class={{
-                'secondary-btn': this.canEndMeeting,
-                'secondary-danger-btn': this.canEndMeeting,
-              }}
-            >
+            <rtk-button variant="danger" title={this.t('leave')} onClick={this.handleLeave}>
               {this.t('leave')}
             </rtk-button>
 
             {this.canEndMeeting && (
-              <rtk-button variant="danger" onClick={this.handleEndMeeting}>
+              <rtk-button
+                variant="danger"
+                class="secondary-btn secondary-danger-btn"
+                onClick={this.handleEndMeeting}
+              >
                 {this.t('end.all')}
               </rtk-button>
             )}


### PR DESCRIPTION
### Description

For users who sometimes (but don't always) have permission to end a
meeting for everyone, the big red button was doing different things,
which could potentially lead someone unintentionally ending the meeting
for everyone when they were only trying to leave the meeting. By using
consistent "primary" styling for the "Leave" button, we can prevent
this, and de-emphasize the most destructive action.

### Screenshots

User who has permission to end meeting:
<img width="1792" alt="image" src="https://github.com/user-attachments/assets/33ed7884-c599-414d-b9f3-9cbb087c94ac" />

User who does not have permission to end meeting:
<img width="1792" alt="image" src="https://github.com/user-attachments/assets/bd87fd0e-f60e-4ce0-9d0b-f2787bb377ad" />
