### PR TITLE
feat(rtk-notifications): pause notification timeouts while focused/hovered

### DIFF
--- a/packages/angular-library/projects/components/src/lib/stencil-generated/components.ts
+++ b/packages/angular-library/projects/components/src/lib/stencil-generated/components.ts
@@ -2307,14 +2307,14 @@ export declare interface RtkNetworkIndicator extends Components.RtkNetworkIndica
 
 
 @ProxyCmp({
-  inputs: ['iconPack', 'notification', 'size', 't']
+  inputs: ['iconPack', 'notification', 'paused', 'size', 't']
 })
 @Component({
   selector: 'rtk-notification',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['iconPack', 'notification', 'size', 't'],
+  inputs: ['iconPack', 'notification', 'paused', 'size', 't'],
 })
 export class RtkNotification {
   protected el: HTMLRtkNotificationElement;

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -2369,6 +2369,10 @@ export namespace Components {
          */
         "notification": Notification;
         /**
+          * Stops timeout when true
+         */
+        "paused": boolean;
+        /**
           * Size
          */
         "size": Size;
@@ -9149,6 +9153,10 @@ declare namespace LocalJSX {
           * Dismiss event
          */
         "onRtkNotificationDismiss"?: (event: RtkNotificationCustomEvent<string>) => void;
+        /**
+          * Stops timeout when true
+         */
+        "paused"?: boolean;
         /**
           * Size
          */

--- a/packages/core/src/components/rtk-notification/rtk-notification.css
+++ b/packages/core/src/components/rtk-notification/rtk-notification.css
@@ -9,7 +9,7 @@
 }
 
 .ctr {
-  @apply min-w-40 box-border inline-flex h-full items-center px-3;
+  @apply min-w-40 box-border inline-flex h-full items-center pl-3 pr-2;
   @apply bg-background-600 select-none rounded-md;
   @apply shadow-background-1000 shadow-md;
   @apply pointer-events-auto;
@@ -42,22 +42,23 @@ rtk-icon.icon {
   @apply text-text-900;
 }
 
-rtk-icon.dismiss {
-  @apply ml-auto h-5 w-5;
-  @apply text-text-600 hover:text-text-1000 rounded-md hover:cursor-pointer;
+button.dismiss {
+  @apply flex h-6 w-6 items-center justify-center border-none p-0;
+  @apply text-text-600 outline-text-1000 rounded-sm bg-transparent outline-1;
+  @apply hover:text-text-1000 hover:cursor-pointer focus-visible:outline;
   @apply transition-colors;
 }
 
+.dismiss rtk-icon {
+  @apply h-5 w-5;
+}
+
 rtk-button {
-  @apply ml-4 mr-2 rounded-sm;
+  @apply rounded-sm;
 }
 
 .right {
-  @apply ml-auto flex items-center;
-
-  & > * {
-    @apply ml-2 first:ml-0;
-  }
+  @apply ml-auto flex items-center gap-2;
 }
 
 :host(.exit) {

--- a/packages/core/src/components/rtk-notification/rtk-notification.tsx
+++ b/packages/core/src/components/rtk-notification/rtk-notification.tsx
@@ -20,6 +20,9 @@ export class RtkNotification {
   /** Message */
   @Prop() notification!: Notification;
 
+  /** Stops timeout when true */
+  @Prop() paused: boolean;
+
   /** Size */
   @SyncWithStore() @Prop({ reflect: true }) size: Size;
 
@@ -42,10 +45,21 @@ export class RtkNotification {
     this.notificationChanged(this.notification);
   }
 
+  private timeout: number;
+
+  @Watch('paused')
+  pausedChanged(paused: boolean) {
+    if (paused) {
+      clearTimeout(this.timeout);
+    } else {
+      this.notificationChanged(this.notification);
+    }
+  }
+
   @Watch('notification')
   notificationChanged(notification: Notification) {
-    if (notification != null && typeof notification.duration === 'number') {
-      setTimeout(() => {
+    if (notification != null && typeof notification.duration === 'number' && !this.paused) {
+      this.timeout = window.setTimeout(() => {
         this.dismiss.emit(notification.id);
       }, notification.duration);
     }
@@ -85,12 +99,9 @@ export class RtkNotification {
                 {this.notification.button.text}
               </rtk-button>
             )}
-            <rtk-icon
-              aria-label={this.t('dismiss')}
-              class="dismiss"
-              icon={this.iconPack.dismiss}
-              onClick={() => this.dismiss.emit(this.notification.id)}
-            />
+            <button onClick={() => this.dismiss.emit(this.notification.id)} class="dismiss">
+              <rtk-icon aria-label={this.t('dismiss')} icon={this.iconPack.dismiss} />
+            </button>
           </div>
         </div>
       </Host>

--- a/packages/core/src/components/rtk-notifications/rtk-notifications.tsx
+++ b/packages/core/src/components/rtk-notifications/rtk-notifications.tsx
@@ -651,20 +651,31 @@ export class RtkNotifications {
     );
   }
 
+  @State()
+  paused = false;
+
   render() {
     return (
       <Host>
-        {this.notifications.map((notification) => (
-          <rtk-notification
-            size={this.size}
-            key={notification.id}
-            data-id={notification.id}
-            notification={notification}
-            onRtkNotificationDismiss={(e: CustomEvent<string>) => this.handleDismiss(e)}
-            iconPack={this.iconPack}
-            t={this.t}
-          />
-        ))}
+        <div
+          onMouseEnter={() => (this.paused = true)}
+          onFocusin={() => (this.paused = true)}
+          onMouseLeave={() => (this.paused = false)}
+          onFocusout={() => (this.paused = false)}
+        >
+          {this.notifications.map((notification) => (
+            <rtk-notification
+              size={this.size}
+              key={notification.id}
+              data-id={notification.id}
+              notification={notification}
+              onRtkNotificationDismiss={(e: CustomEvent<string>) => this.handleDismiss(e)}
+              iconPack={this.iconPack}
+              paused={this.paused}
+              t={this.t}
+            />
+          ))}
+        </div>
       </Host>
     );
   }

--- a/packages/vue-library/lib/components.ts
+++ b/packages/vue-library/lib/components.ts
@@ -1014,6 +1014,7 @@ export const RtkNetworkIndicator = /*@__PURE__*/ defineContainer<JSX.RtkNetworkI
 
 export const RtkNotification = /*@__PURE__*/ defineContainer<JSX.RtkNotification>('rtk-notification', undefined, [
   'notification',
+  'paused',
   'size',
   'iconPack',
   't',


### PR DESCRIPTION
### Description
- After playing around for a little bit with the webinar functionality I noticed the notifications can disappear from under you if you're not fast enough while trying to click. To alleviate this, we can stop the timeout when the user is about to interact with the notification (either via focus or mouseover) and restart it when they either move the mouse out or focus something other than a notification.
- Also made the dismiss icon into a button!
