### PR TITLE
fix(header components): replace margin with gap

### DIFF
--- a/packages/core/src/components/rtk-clock/rtk-clock.css
+++ b/packages/core/src/components/rtk-clock/rtk-clock.css
@@ -1,7 +1,7 @@
 @import '../../styles/reset.css';
 
 :host {
-  @apply mx-2 inline-flex items-center;
+  @apply inline-flex items-center;
   @apply text-text-md select-none;
   @apply text-text-1000;
 
@@ -9,8 +9,13 @@
   font-variant-numeric: tabular-nums;
 }
 
+/* useful for removing from layouts that may have gap */
+:host([data-hidden]) {
+  display: none;
+}
+
 :host([size='sm']) {
-  @apply text-text-sm mx-1;
+  @apply text-text-sm;
 }
 
 rtk-icon {

--- a/packages/core/src/components/rtk-clock/rtk-clock.tsx
+++ b/packages/core/src/components/rtk-clock/rtk-clock.tsx
@@ -86,8 +86,9 @@ export class RtkClock {
   }
 
   render() {
+    const showClock = this.startedTime !== undefined;
     return (
-      <Host tabIndex={0} role="timer" aria-live="off">
+      <Host data-hidden={!showClock} tabIndex={0} role="timer" aria-live="off">
         {this.startedTime !== undefined && [
           <rtk-icon icon={this.iconPack.clock} aria-hidden={true} tabIndex={-1} part="icon" />,
           <span part="text">{this.getFormattedTime()}</span>,

--- a/packages/core/src/components/rtk-grid-pagination/rtk-grid-pagination.css
+++ b/packages/core/src/components/rtk-grid-pagination/rtk-grid-pagination.css
@@ -1,11 +1,16 @@
 @import '../../styles/reset.css';
 
 :host {
-  @apply text-text-lg mx-2 flex select-none items-center;
+  @apply text-text-lg flex select-none items-center;
+}
+
+/* useful for removing from layouts that may have gap */
+:host([data-hidden]) {
+  display: none;
 }
 
 :host([size='sm']) {
-  @apply text-text-sm mx-1;
+  @apply text-text-sm;
 
   .center {
     @apply mx-0;
@@ -54,8 +59,6 @@ rtk-button {
 }
 
 :host([variant='grid']) {
-  @apply mx-0;
-
   rtk-button {
     @apply absolute top-1/2 h-20 w-20;
     @apply opacity-20 transition hover:opacity-100;

--- a/packages/core/src/components/rtk-grid-pagination/rtk-grid-pagination.tsx
+++ b/packages/core/src/components/rtk-grid-pagination/rtk-grid-pagination.tsx
@@ -162,7 +162,7 @@ export class RtkGridPagination {
     const isAudioRoom = meta?.viewType === 'AUDIO_ROOM';
 
     if (isAudioRoom || !this.showPagination) {
-      return;
+      return <Host data-hidden />;
     }
 
     return (

--- a/packages/core/src/components/rtk-livestream-indicator/rtk-livestream-indicator.css
+++ b/packages/core/src/components/rtk-livestream-indicator/rtk-livestream-indicator.css
@@ -4,6 +4,11 @@
   @apply mx-2 flex;
 }
 
+/* useful for removing from layouts that may have gap */
+:host([data-hidden]) {
+  display: none;
+}
+
 :host[size='sm'] {
   @apply mx-1;
 }

--- a/packages/core/src/components/rtk-livestream-indicator/rtk-livestream-indicator.tsx
+++ b/packages/core/src/components/rtk-livestream-indicator/rtk-livestream-indicator.tsx
@@ -50,7 +50,7 @@ export class RtkLivestreamIndicator {
   };
 
   render() {
-    if (!showLivestream(this.meeting) || !this.isLivestreaming) return;
+    if (!showLivestream(this.meeting) || !this.isLivestreaming) return <Host data-hidden />;
 
     return (
       <Host>

--- a/packages/core/src/components/rtk-meeting-title/rtk-meeting-title.css
+++ b/packages/core/src/components/rtk-meeting-title/rtk-meeting-title.css
@@ -1,8 +1,13 @@
 @import '../../styles/reset.css';
 
 :host {
-  @apply text-text-lg mx-3 select-none;
+  @apply text-text-lg select-none;
   @apply text-text-1000;
+}
+
+/* useful for removing from layouts that may have gap */
+:host([data-hidden]) {
+  display: none;
 }
 
 .title {

--- a/packages/core/src/components/rtk-meeting-title/rtk-meeting-title.tsx
+++ b/packages/core/src/components/rtk-meeting-title/rtk-meeting-title.tsx
@@ -31,10 +31,10 @@ export class RtkMeetingTitle {
   render() {
     const title = this.meeting?.meta.meetingTitle;
 
-    if (title == null) return null;
+    if (title == null) return <Host data-hidden />;
 
     return (
-      <Host tabIndex={0} role="banner" aria-label={title}>
+      <Host role="banner" aria-label={title}>
         <rtk-tooltip label={title} part="tooltip">
           <div class="title" part="title">
             {title}

--- a/packages/core/src/components/rtk-participant-count/rtk-participant-count.css
+++ b/packages/core/src/components/rtk-participant-count/rtk-participant-count.css
@@ -1,11 +1,16 @@
 @import '../../styles/reset.css';
 
 :host {
-  @apply mx-2 inline-flex h-10 select-none items-center;
+  @apply inline-flex h-10 select-none items-center;
+}
+
+/* useful for removing from layouts that may have gap */
+:host([data-hidden]) {
+  display: none;
 }
 
 :host([size='sm']) {
-  @apply text-text-sm mx-1;
+  @apply text-text-sm;
 }
 
 rtk-icon {

--- a/packages/core/src/components/rtk-participant-count/rtk-participant-count.tsx
+++ b/packages/core/src/components/rtk-participant-count/rtk-participant-count.tsx
@@ -85,7 +85,7 @@ export class RtkParticipantCount {
   }
 
   render() {
-    if (this.isViewer) return null;
+    if (this.isViewer) return <Host data-hidden />;
     return (
       <Host
         tabIndex={0}

--- a/packages/core/src/components/rtk-recording-indicator/rtk-recording-indicator.css
+++ b/packages/core/src/components/rtk-recording-indicator/rtk-recording-indicator.css
@@ -1,7 +1,12 @@
 @import '../../styles/reset.css';
 
 :host {
-  @apply mx-2 block;
+  @apply block;
+}
+
+/* useful for removing from layouts that may have gap */
+:host([data-hidden]) {
+  display: none;
 }
 
 :host[size='sm'] {

--- a/packages/core/src/components/rtk-recording-indicator/rtk-recording-indicator.tsx
+++ b/packages/core/src/components/rtk-recording-indicator/rtk-recording-indicator.tsx
@@ -65,7 +65,7 @@ export class RtkRecordingIndicator {
 
   render() {
     return (
-      <Host>
+      <Host data-hidden={!this.isRecording}>
         {this.isRecording && (
           <div class="indicator" aria-label={this.t('recording.indicator')} part="indicator">
             <rtk-icon icon={this.iconPack.recording} aria-hidden={true} tabIndex={-1} part="icon" />

--- a/packages/core/src/components/rtk-viewer-count/rtk-viewer-count.css
+++ b/packages/core/src/components/rtk-viewer-count/rtk-viewer-count.css
@@ -1,11 +1,16 @@
 @import '../../styles/reset.css';
 
 :host {
-  @apply text-text-md mx-2 inline-flex h-10 select-none items-center;
+  @apply text-text-md inline-flex h-10 select-none items-center;
+}
+
+/* useful for removing from layouts that may have gap */
+:host([data-hidden]) {
+  display: none;
 }
 
 :host([size='sm']) {
-  @apply text-text-sm mx-1;
+  @apply text-text-sm;
 }
 
 rtk-icon {

--- a/packages/core/src/components/rtk-viewer-count/rtk-viewer-count.tsx
+++ b/packages/core/src/components/rtk-viewer-count/rtk-viewer-count.tsx
@@ -65,7 +65,7 @@ export class RtkViewerCount {
   }
 
   render() {
-    if (!showLivestream(this.meeting)) return null;
+    if (!showLivestream(this.meeting)) return <Host data-hidden />;
     return (
       <Host tabIndex={0} role="log" aria-label={`${this.viewerCount} ${this.t('viewers')}`}>
         <rtk-icon icon={this.iconPack.viewers} tabIndex={-1} aria-hidden={true} part="icon" />

--- a/packages/core/src/lib/default-ui-config.ts
+++ b/packages/core/src/lib/default-ui-config.ts
@@ -20,6 +20,7 @@ export const defaultConfig: UIConfig = {
       gridTemplateColumns: 'repeat(3, 1fr)',
       gridTemplateRows: '1fr',
       alignItems: 'center',
+      '--header-section-gap': 'var(--dyte-space-2, 8px)',
     },
     'rtk-header.sm': {
       display: 'grid',
@@ -27,12 +28,14 @@ export const defaultConfig: UIConfig = {
       gridTemplateColumns: 'repeat(2, 1fr)',
       gridTemplateRows: '1fr',
       alignItems: 'center',
+      '--header-section-gap': 'var(--dyte-space-1, 4px)',
     },
     'div#header-left': {
       display: 'flex',
       alignItems: 'center',
       height: '48px',
       wordBreak: 'break-all',
+      gap: 'var(--header-section-gap)',
     },
     'rtk-logo': {
       height: '26px',
@@ -42,11 +45,14 @@ export const defaultConfig: UIConfig = {
       alignItems: 'center',
       justifyContent: 'center',
       wordBreak: 'break-all',
+      gap: 'var(--header-section-gap)',
+      paddingInline: 'var(--dyte-space-3, 12px)',
     },
     'div#header-right': {
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'flex-end',
+      gap: 'var(--header-section-gap)',
     },
     'rtk-stage': {
       display: 'flex',

--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -240,6 +240,7 @@ export const generateConfig = (
         gridTemplateColumns: 'repeat(3, 1fr)',
         gridTemplateRows: '1fr',
         alignItems: 'center',
+        '--header-section-gap': 'var(--dyte-space-2, 8px)',
       },
       'rtk-header.sm': {
         display: 'grid',
@@ -247,12 +248,14 @@ export const generateConfig = (
         gridTemplateColumns: 'repeat(2, 1fr)',
         gridTemplateRows: '1fr',
         alignItems: 'center',
+        '--header-section-gap': 'var(--dyte-space-1, 4px)',
       },
       'div#header-left': {
         display: 'flex',
         alignItems: 'center',
         height: '48px',
         wordBreak: 'break-all',
+        gap: 'var(--header-section-gap)',
       },
       'rtk-logo': {
         height: '26px',
@@ -262,11 +265,14 @@ export const generateConfig = (
         alignItems: 'center',
         justifyContent: 'center',
         wordBreak: 'break-all',
+        gap: 'var(--header-section-gap)',
+        paddingInline: 'var(--dyte-space-3, 12px)',
       },
       'div#header-right': {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'flex-end',
+        gap: 'var(--header-section-gap)',
       },
       'rtk-stage': {
         display: 'flex',


### PR DESCRIPTION
BREAKING CHANGE: The following components no longer have margin:
- rtk-clock
- rtk-grid-pagination
- rtk-livestream-indicator
- rtk-meeting-title
- rtk-participan-count
- rtk-recording-indicator
- rtk-viewer-count

### Description

In order to make these components easier to use individually, we're removing margin! As a sidenote, it looks like the `dyte-viewer-count` was rendering margin despite being "empty" which was pushing the `dyte`participant-count` and `dyte-clock` farther apart than was intended. This has been fixed!

### Screenshots

Before (larger viewport):
<img width="2672" alt="image" src="https://github.com/user-attachments/assets/799a69bb-5686-4c4e-82c0-5112c99e2ff6" />

After (larger viewport):
<img width="2672" alt="image" src="https://github.com/user-attachments/assets/4a9f8074-5fbf-49e1-b50c-64771edb849c" />

Before (smaller viewport):
<img width="2672" alt="image" src="https://github.com/user-attachments/assets/3cdef1a7-dee9-4c1f-aa8d-540950c194e1" />

After (smaller viewport):
<img width="2672" alt="image" src="https://github.com/user-attachments/assets/139dd606-cc3b-45c2-b131-d6af94fc87db" />