### PR TITLE
feat(sidebar and sidebar toggles): improvements when opening/closing sidebars

### DIFF
--- a/packages/angular-library/projects/components/src/lib/stencil-generated/components.ts
+++ b/packages/angular-library/projects/components/src/lib/stencil-generated/components.ts
@@ -3243,14 +3243,14 @@ export declare interface RtkSidebar extends Components.RtkSidebar {
 
 
 @ProxyCmp({
-  inputs: ['currentTab', 'hideCloseAction', 'hideHeader', 'iconPack', 't', 'tabs', 'view']
+  inputs: ['currentTab', 'focusCloseButton', 'hideCloseAction', 'hideHeader', 'iconPack', 't', 'tabs', 'view']
 })
 @Component({
   selector: 'rtk-sidebar-ui',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['currentTab', 'hideCloseAction', 'hideHeader', 'iconPack', 't', 'tabs', 'view'],
+  inputs: ['currentTab', 'focusCloseButton', 'hideCloseAction', 'hideHeader', 'iconPack', 't', 'tabs', 'view'],
 })
 export class RtkSidebarUi {
   protected el: HTMLRtkSidebarUiElement;

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -3402,6 +3402,10 @@ export namespace Components {
          */
         "currentTab": string;
         /**
+          * Option to focus close button when opened
+         */
+        "focusCloseButton": boolean;
+        /**
           * Hide Close Action
          */
         "hideCloseAction": boolean;
@@ -10285,6 +10289,10 @@ declare namespace LocalJSX {
           * Default tab to open
          */
         "currentTab"?: string;
+        /**
+          * Option to focus close button when opened
+         */
+        "focusCloseButton"?: boolean;
         /**
           * Hide Close Action
          */

--- a/packages/core/src/components/rtk-button/rtk-button.tsx
+++ b/packages/core/src/components/rtk-button/rtk-button.tsx
@@ -16,7 +16,7 @@ export type ButtonKind = 'button' | 'icon' | 'wide';
 @Component({
   tag: 'rtk-button',
   styleUrl: 'rtk-button.css',
-  shadow: true,
+  shadow: { delegatesFocus: true },
 })
 export class RtkButton {
   /** Size */

--- a/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
+++ b/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
@@ -129,6 +129,16 @@ export class RtkChatToggle {
     this.canViewChat = canViewChat(this.meeting);
   };
 
+  @Watch('chatActive')
+  handleChatActiveChange() {
+    // Chat sidebar closed without opening a different sidebar
+    if (!this.chatActive && !this.states.activeSidebar) {
+      this.buttonEl.focus();
+    }
+  }
+
+  private buttonEl: HTMLRtkControlbarButtonElement;
+
   render() {
     if (!this.canViewChat) return <Host data-hidden />;
     return (
@@ -142,6 +152,7 @@ export class RtkChatToggle {
               </div>
             )}
         <rtk-controlbar-button
+          ref={(el) => (this.buttonEl = el)}
           part="controlbar-button"
           size={this.size}
           iconPack={this.iconPack}

--- a/packages/core/src/components/rtk-controlbar-button/rtk-controlbar-button.tsx
+++ b/packages/core/src/components/rtk-controlbar-button/rtk-controlbar-button.tsx
@@ -11,7 +11,7 @@ export type ControlBarVariant = 'button' | 'horizontal';
 @Component({
   tag: 'rtk-controlbar-button',
   styleUrl: 'rtk-controlbar-button.css',
-  shadow: true,
+  shadow: { delegatesFocus: true },
 })
 export class RtkControlbarButton {
   /** Variant */

--- a/packages/core/src/components/rtk-participants-toggle/rtk-participants-toggle.tsx
+++ b/packages/core/src/components/rtk-participants-toggle/rtk-participants-toggle.tsx
@@ -162,10 +162,19 @@ export class RtkParticipantsToggle {
     this.canViewParticipants = canViewParticipants(this.meeting);
   };
 
+  @Watch('participantsActive')
+  handleParticipantsActiveChange() {
+    // Participants sidebar closed without opening a different sidebar
+    if (!this.participantsActive && !this.states.activeSidebar) {
+      this.buttonEl.focus();
+    }
+  }
+
+  private buttonEl: HTMLRtkControlbarButtonElement;
+
   render() {
     if (!this.canViewParticipants) return <Host data-hidden />;
     const text = this.t('participants');
-    // const badgeCount = this.waitlistedParticipants.length + this.stageRequestedParticipants.length;
     return (
       <Host title={text}>
         {this.badgeCount !== 0 && !this.participantsActive && (
@@ -174,6 +183,7 @@ export class RtkParticipantsToggle {
           </div>
         )}
         <rtk-controlbar-button
+          ref={(el) => (this.buttonEl = el)}
           part="controlbar-button"
           size={this.size}
           iconPack={this.iconPack}

--- a/packages/core/src/components/rtk-plugins-toggle/rtk-plugins-toggle.tsx
+++ b/packages/core/src/components/rtk-plugins-toggle/rtk-plugins-toggle.tsx
@@ -95,6 +95,16 @@ export class RtkPluginsToggle {
     this.canViewPlugins = canViewPlugins(this.meeting);
   };
 
+  @Watch('pluginsActive')
+  handlePluginsActiveChange() {
+    // Plugins sidebar closed without opening a different sidebar
+    if (!this.pluginsActive && !this.states.activeSidebar) {
+      this.buttonEl.focus();
+    }
+  }
+
+  private buttonEl: HTMLRtkControlbarButtonElement;
+
   render() {
     if (!this.canViewPlugins) return <Host data-hidden />;
 
@@ -103,6 +113,7 @@ export class RtkPluginsToggle {
     return (
       <Host title={text}>
         <rtk-controlbar-button
+          ref={(el) => (this.buttonEl = el)}
           part="controlbar-button"
           size={this.size}
           iconPack={this.iconPack}

--- a/packages/core/src/components/rtk-polls-toggle/rtk-polls-toggle.tsx
+++ b/packages/core/src/components/rtk-polls-toggle/rtk-polls-toggle.tsx
@@ -109,6 +109,16 @@ export class RtkPollsToggle {
     this.canViewPolls = canViewPolls(this.meeting);
   };
 
+  @Watch('pollsActive')
+  handlePollsActiveChange() {
+    // Polls sidebar closed without opening a different sidebar
+    if (!this.pollsActive && !this.states.activeSidebar) {
+      this.buttonEl.focus();
+    }
+  }
+
+  private buttonEl: HTMLRtkControlbarButtonElement;
+
   render() {
     if (!this.canViewPolls) return <Host data-hidden />;
     const text = this.t('polls');
@@ -123,6 +133,7 @@ export class RtkPollsToggle {
           </div>
         )}
         <rtk-controlbar-button
+          ref={(el) => (this.buttonEl = el)}
           part="controlbar-button"
           size={this.size}
           iconPack={this.iconPack}

--- a/packages/core/src/components/rtk-sidebar/rtk-sidebar.tsx
+++ b/packages/core/src/components/rtk-sidebar/rtk-sidebar.tsx
@@ -28,8 +28,6 @@ export type RtkSidebarSection = 'chat' | 'polls' | 'participants' | 'plugins';
   shadow: true,
 })
 export class RtkSidebar {
-  private keydownListener: (e: KeyboardEvent) => void;
-
   private onStageStatusUpdate: (status: StageStatus) => void;
 
   /** Enabled sections in sidebar */
@@ -84,7 +82,6 @@ export class RtkSidebar {
   }
 
   disconnectedCallback() {
-    document.removeEventListener('keydown', this.keydownListener);
     this.meeting?.stage?.removeListener('stageStatusUpdate', this.onStageStatusUpdate);
     this.onStageStatusUpdate = null;
   }
@@ -111,12 +108,6 @@ export class RtkSidebar {
   viewChanged(view: RtkSidebarView) {
     if (view === 'full-screen') {
       this.enablePinning = false;
-      this.keydownListener = (e) => {
-        if (e.key === 'Escape') {
-          this.close();
-        }
-      };
-      document.addEventListener('keydown', this.keydownListener);
     } else {
       this.enablePinning = true;
     }

--- a/packages/vue-library/lib/components.ts
+++ b/packages/vue-library/lib/components.ts
@@ -1432,6 +1432,7 @@ export const RtkSidebarUi = /*@__PURE__*/ defineContainer<JSX.RtkSidebarUi>('rtk
   'hideCloseAction',
   'currentTab',
   'iconPack',
+  'focusCloseButton',
   't',
   'tabChange',
   'sidebarClose'


### PR DESCRIPTION
### Description
- The close button is focused when the sidebar opens
- Pressing Escape while any element within the sidebar is focused will close the sidebar
- When the sidebar is closed, focus is returned to the toggle that opens it