### PR TITLE
fix: bring back border-radius in controlbar button

### DIFF
--- a/packages/core/src/components/rtk-controlbar-button/rtk-controlbar-button.css
+++ b/packages/core/src/components/rtk-controlbar-button/rtk-controlbar-button.css
@@ -9,7 +9,7 @@
 
   @apply relative box-border inline-flex;
   @apply min-w-20 h-full w-auto;
-  @apply select-none transition-colors;
+  @apply select-none rounded-md transition-colors;
   @apply text-text-1000;
 
   background-color: var(--background-color);


### PR DESCRIPTION
Adds border-radius to controlbar button which was removed in an earlier commit, which made the buttons look flat on setup screens and mobile devices.