### PR TITLE
fix: use logger from meeting object

### DIFF
--- a/packages/core/src/components/rtk-screen-share-toggle/rtk-screen-share-toggle.tsx
+++ b/packages/core/src/components/rtk-screen-share-toggle/rtk-screen-share-toggle.tsx
@@ -3,7 +3,6 @@ import { RtkI18n, useLanguage } from '../../lib/lang';
 import { Meeting, Peer, MediaPermission } from '../../types/rtk-client';
 import { PermissionSettings, Size, States } from '../../types/props';
 import { Component, Host, h, Prop, State, Watch, Event, EventEmitter } from '@stencil/core';
-import logger from '../../utils/logger';
 import { ControlBarVariant } from '../rtk-controlbar-button/rtk-controlbar-button';
 import { SyncWithStore } from '../../utils/sync-with-store';
 import { StageStatus } from '@cloudflare/realtimekit';
@@ -159,7 +158,9 @@ export class RtkScreenShareToggle {
 
   connectedCallback() {
     if (!deviceCanScreenShare()) {
-      logger.error('[rtk-screenshare-toggle] Device does not support screensharing.');
+      this.meeting.__internals__.logger.error(
+        '[rtk-screenshare-toggle] Device does not support screensharing.'
+      );
       return;
     }
     this.meetingChanged(this.meeting);

--- a/packages/core/src/lib/audio.ts
+++ b/packages/core/src/lib/audio.ts
@@ -1,6 +1,5 @@
 import { Meeting } from '../types/rtk-client';
 import { disableSettingSinkId } from '../utils/flags';
-import logger from '../utils/logger';
 
 interface PeerAudio {
   id: string;
@@ -17,12 +16,15 @@ export default class RTKAudio {
 
   private audioTracks: PeerAudio[];
 
+  private logger: Meeting['__internals__']['logger'];
+
   private _onError: () => void;
 
   constructor(meeting: Meeting, audio?: HTMLAudioElement) {
     this.meeting = meeting;
     this.audio = audio ?? document.createElement('audio');
     this.audio.autoplay = true;
+    this.logger = meeting.__internals__.logger;
 
     this.audioStream = new MediaStream();
     this.audio.srcObject = this.audioStream;
@@ -56,7 +58,7 @@ export default class RTKAudio {
           this._onError();
         }
       } else if (err.name !== 'AbortError') {
-        logger.error('[rtk-audio] play() error\n', err);
+        this.logger.error('[rtk-audio] play() error\n', err);
       }
     });
   }
@@ -64,7 +66,7 @@ export default class RTKAudio {
   async setDevice(id: string) {
     if (disableSettingSinkId(this.meeting)) return;
     await (this.audio as any).setSinkId?.(id)?.catch((err) => {
-      logger.error('[rtk-audio] setSinkId() error\n', err);
+      this.logger.error('[rtk-audio] setSinkId() error\n', err);
     });
   }
 

--- a/packages/core/src/lib/notification.ts
+++ b/packages/core/src/lib/notification.ts
@@ -1,6 +1,5 @@
 import { Meeting } from '../types/rtk-client';
 import { disableSettingSinkId } from '../utils/flags';
-import logger from '../utils/logger';
 
 const SOUNDS = {
   joined: 'https://dyte-uploads.s3.ap-south-1.amazonaws.com/notification_join.mp3',
@@ -31,9 +30,7 @@ export default class RTKNotificationsAudio {
 
     this.audio.src = SOUNDS[sound];
     this.audio.volume = 0.3;
-    this.audio.play()?.catch((err) => {
-      logger.error('[rtk-notifications] play() failed\n', { sound, duration }, err);
-    });
+    this.audio.play()?.catch((_) => {});
 
     setTimeout(() => {
       this.playing = false;
@@ -42,8 +39,6 @@ export default class RTKNotificationsAudio {
 
   async setDevice(id: string) {
     if (disableSettingSinkId(this.meeting)) return;
-    await (this.audio as any)?.setSinkId?.(id)?.catch((err) => {
-      logger.error('[rtk-notifications] setSinkId() error\n', err);
-    });
+    await (this.audio as any)?.setSinkId?.(id)?.catch((_) => {});
   }
 }

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -1,1 +1,0 @@
-export default console;


### PR DESCRIPTION
Use logger from SDK, currently logger is console and we do not receive these logs in NewRelic 