### PR TITLE
fix: handle missing meetingTitle to prevent trim error

### DIFF
--- a/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.tsx
+++ b/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.tsx
@@ -125,7 +125,7 @@ export class RtkSetupScreen {
       t: this.t,
     };
 
-    const meetingTitle = this.meeting?.meta.meetingTitle.trim();
+    const meetingTitle = this.meeting?.meta?.meetingTitle?.trim();
 
     return (
       <Host>


### PR DESCRIPTION
… is not set.

### Description

Fix the issue where calling trim might cause an error if meetingTitle is not set.

### Screenshots

<!-- Add screenshots if applicable -->
