### PR TITLE
fix(singleton-issues): fixed singleton issues around double notifications/chats

### DIFF
--- a/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
+++ b/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
@@ -10,6 +10,7 @@ import {
   UIConfig,
   useLanguage,
   defaultIconPack,
+  provideRtkDesignSystem,
 } from '../../exports';
 import {
   uiStore as legacyGlobalUIStore,
@@ -244,6 +245,14 @@ export class RtkUiProvider {
   onConfigChange(config: UIConfig) {
     if (this.peerStore) {
       this.peerStore.state.config = config;
+    }
+
+    if (
+      config?.designTokens &&
+      typeof document !== 'undefined' &&
+      (this.peerStore || legacyGlobalUIStore).state.states.activeDebugger !== true
+    ) {
+      provideRtkDesignSystem(document.documentElement, config.designTokens);
     }
   }
 

--- a/packages/core/src/utils/sync-with-store/index.ts
+++ b/packages/core/src/utils/sync-with-store/index.ts
@@ -38,7 +38,15 @@ export function SyncWithStore() {
           
           // Blindly put peer specific store's value for propName in host propName
           const storeValue = event.detail.store.state[propName];
-          host[propName as string] = storeValue;
+          host.componentOnReady().then(() => {
+            /**
+             * NOTE(ravindra-dyte):
+             * https://stenciljs.com/docs/api#componentonready
+             * This psudo ready callback is to ensure that the component is ready to accept props
+             * Without this, changing the prop would not trigger @Watch of prop in the initial mount phase
+             *  */
+            host[propName as string] = storeValue;
+          });
           appendElement(propName, host, event.detail.store);
           host[`_rtkStoreToCleanup-${propName}`] = event.detail.store;
           // Since peer specific store is available, remove element prop from global store

--- a/packages/core/src/utils/sync-with-store/ui-store.ts
+++ b/packages/core/src/utils/sync-with-store/ui-store.ts
@@ -48,14 +48,14 @@ const elementsMap = new Map<string, any[]>();
 (uiStore as any).elementsMap = elementsMap;
 
 uiStore.use({
-  set: (propName, newValue, oldValue) => {
+  set: (propName, newValue) => {
     const elements = elementsMap.get(propName as string);
     if (elements) {
       elementsMap.set(
         propName as string,
         elements.filter((element) => {
           const currentValue = element[propName];
-          if (currentValue === oldValue) {
+          if (currentValue !== newValue) {
             element[propName] = newValue;
             return true;
           } else {
@@ -106,14 +106,14 @@ export function createPeerStore({
   (store as RtkUiStoreExtended).elementsMap = peerElementsMap;
 
   store.use({
-    set: (propName, newValue, oldValue) => {
+    set: (propName, newValue) => {
       const elements = peerElementsMap.get(propName as string);
       if (elements) {
         peerElementsMap.set(
           propName as string,
           elements.filter((element) => {
             const currentValue = element[propName];
-            if (currentValue === oldValue) {
+            if (currentValue !== newValue) {
               element[propName] = newValue;
               return true;
             } else {


### PR DESCRIPTION
### Description

1. Fixed the issue where double notifications were triggered for participant joins, recordings, chats and so on. It was happening because meetingChanged was called from connectedCallback as well as the storeResponseListener. However sometimes it would work fine because of the nature of Stencil where in the first render phase, any prop change does not retrigger the render and neither triggeres @watch for the property.

2. Fixed the base design system so that display flex can be used to fix control bar & header.
