### PR TITLE
fix(store-sync-issues): in some cases, rtk-meeting was not syncing its state with peer store

### DIFF
--- a/packages/core/src/components/rtk-meeting/rtk-meeting.tsx
+++ b/packages/core/src/components/rtk-meeting/rtk-meeting.tsx
@@ -147,6 +147,10 @@ export class RtkMeeting {
     this.setupStateUpdateListener();
 
     this.meetingChanged(this.meeting);
+    this.iconPackChanged(this.iconPack);
+    this.tChanged(this.t);
+    this.configChanged(this.config);
+    this.sizeChanged(this.size);
 
     this.resizeObserver = new ResizeObserver(() => this.handleResize());
     this.resizeObserver.observe(this.host);
@@ -325,10 +329,39 @@ export class RtkMeeting {
     });
   };
 
+  @Watch('iconPack')
+  iconPackChanged(newIconPack: IconPack) {
+    if (this.peerStore) {
+      this.peerStore.state.iconPack = newIconPack;
+    }
+  }
+
+  @Watch('t')
+  tChanged(newT: RtkI18n) {
+    if (this.peerStore) {
+      this.peerStore.state.t = newT;
+    }
+  }
+
   @Watch('size')
-  onSizeChange(newSize: Size) {
+  sizeChanged(newSize: Size) {
     if (this.peerStore) {
       this.peerStore.state.size = newSize;
+    }
+  }
+
+  @Watch('config')
+  configChanged(config: UIConfig) {
+    if (this.peerStore) {
+      this.peerStore.state.config = config;
+    }
+
+    if (
+      config?.designTokens &&
+      typeof document !== 'undefined' &&
+      (this.peerStore || legacyGlobalUIStore).state.states.activeDebugger !== true
+    ) {
+      provideRtkDesignSystem(document.documentElement, config.designTokens);
     }
   }
 

--- a/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
+++ b/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
@@ -10,6 +10,7 @@ import {
   UIConfig,
   useLanguage,
   defaultIconPack,
+  provideRtkDesignSystem,
 } from '../../exports';
 import {
   uiStore as legacyGlobalUIStore,
@@ -244,6 +245,14 @@ export class RtkUiProvider {
   onConfigChange(config: UIConfig) {
     if (this.peerStore) {
       this.peerStore.state.config = config;
+    }
+
+    if (
+      config?.designTokens &&
+      typeof document !== 'undefined' &&
+      (this.peerStore || legacyGlobalUIStore).state.states.activeDebugger !== true
+    ) {
+      provideRtkDesignSystem(document.documentElement, config.designTokens);
     }
   }
 

--- a/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
+++ b/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
@@ -84,11 +84,11 @@ export class RtkUiProvider {
     // Listen for store requests from child components
     this.setupStoreRequestListener();
 
-    this.onMeetingChange(this.meeting);
-    this.onIconPackChange(this.iconPack);
-    this.onTChange(this.t);
-    this.onConfigChange(this.config);
-    this.onSizeChange(this.size);
+    this.meetingChanged(this.meeting);
+    this.iconPackChanged(this.iconPack);
+    this.tChanged(this.t);
+    this.configChanged(this.config);
+    this.sizeChanged(this.size);
 
     this.resizeObserver = new ResizeObserver(() => this.handleResize());
     this.resizeObserver.observe(this.host);
@@ -173,7 +173,7 @@ export class RtkUiProvider {
   }
 
   @Watch('meeting')
-  onMeetingChange(meeting: Meeting) {
+  meetingChanged(meeting: Meeting) {
     if (meeting) {
       this.peerStore = createPeerStore({
         meeting,
@@ -228,21 +228,21 @@ export class RtkUiProvider {
   }
 
   @Watch('iconPack')
-  onIconPackChange(newIconPack: IconPack) {
+  iconPackChanged(newIconPack: IconPack) {
     if (this.peerStore) {
       this.peerStore.state.iconPack = newIconPack;
     }
   }
 
   @Watch('t')
-  onTChange(newT: RtkI18n) {
+  tChanged(newT: RtkI18n) {
     if (this.peerStore) {
       this.peerStore.state.t = newT;
     }
   }
 
   @Watch('config')
-  onConfigChange(config: UIConfig) {
+  configChanged(config: UIConfig) {
     if (this.peerStore) {
       this.peerStore.state.config = config;
     }
@@ -257,7 +257,7 @@ export class RtkUiProvider {
   }
 
   @Watch('size')
-  onSizeChange(newSize: Size) {
+  sizeChanged(newSize: Size) {
     if (this.peerStore) {
       this.peerStore.state.size = newSize;
     }

--- a/packages/core/src/utils/sync-with-store/index.ts
+++ b/packages/core/src/utils/sync-with-store/index.ts
@@ -38,7 +38,15 @@ export function SyncWithStore() {
           
           // Blindly put peer specific store's value for propName in host propName
           const storeValue = event.detail.store.state[propName];
-          host[propName as string] = storeValue;
+          host.componentOnReady().then(() => {
+            /**
+             * NOTE(ravindra-dyte):
+             * https://stenciljs.com/docs/api#componentonready
+             * This psudo ready callback is to ensure that the component is ready to accept props
+             * Without this, changing the prop would not trigger @Watch of prop in the initial mount phase
+             *  */
+            host[propName as string] = storeValue;
+          });
           appendElement(propName, host, event.detail.store);
           host[`_rtkStoreToCleanup-${propName}`] = event.detail.store;
           // Since peer specific store is available, remove element prop from global store

--- a/packages/core/src/utils/sync-with-store/ui-store.ts
+++ b/packages/core/src/utils/sync-with-store/ui-store.ts
@@ -48,14 +48,14 @@ const elementsMap = new Map<string, any[]>();
 (uiStore as any).elementsMap = elementsMap;
 
 uiStore.use({
-  set: (propName, newValue, oldValue) => {
+  set: (propName, newValue) => {
     const elements = elementsMap.get(propName as string);
     if (elements) {
       elementsMap.set(
         propName as string,
         elements.filter((element) => {
           const currentValue = element[propName];
-          if (currentValue === oldValue) {
+          if (currentValue !== newValue) {
             element[propName] = newValue;
             return true;
           } else {
@@ -106,14 +106,14 @@ export function createPeerStore({
   (store as RtkUiStoreExtended).elementsMap = peerElementsMap;
 
   store.use({
-    set: (propName, newValue, oldValue) => {
+    set: (propName, newValue) => {
       const elements = peerElementsMap.get(propName as string);
       if (elements) {
         peerElementsMap.set(
           propName as string,
           elements.filter((element) => {
             const currentValue = element[propName];
-            if (currentValue === oldValue) {
+            if (currentValue !== newValue) {
               element[propName] = newValue;
               return true;
             } else {


### PR DESCRIPTION
### Description

Just like all other files, ensuring to populate peer store if in case, meeting prop is attached and @Watch for meeting is not triggered.

Due to this bug, UI Kit Addons such as Hand Raise were not being registed in dyte-participants because the config of rtk-meeting was not synced with rtk-participants.

Following same method naming conventions in rtk-ui-provider
