### PR TITLE
fix(rtk-spinner): spinner is out of place for sm size in setup screen

### DIFF
--- a/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.css
+++ b/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.css
@@ -55,6 +55,13 @@ rtk-spinner {
   @apply text-text-1000;
 }
 
+:host([size="md"]) rtk-spinner {
+  --icon-size: theme('spacing.6');
+}
+:host([size="lg"]) rtk-spinner {
+  --icon-size: theme('spacing.8');
+}
+
 :host([size='sm']) .container,
 :host([size='md']) .container {
   @apply h-full flex-col justify-evenly;

--- a/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.css
+++ b/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.css
@@ -53,7 +53,6 @@ input {
 
 rtk-spinner {
   @apply text-text-1000;
-  --icon-size: theme('spacing.8');
 }
 
 :host([size='sm']) .container,


### PR DESCRIPTION
### Description

Spinner was out of place in setup screen for smaller screens.

### Screenshots

Before
<img width="488" height="692" alt="image" src="https://github.com/user-attachments/assets/ba43f0b5-7165-432d-9685-eb40d0248801" />

After

https://github.com/user-attachments/assets/c655f7c7-776d-4f39-9b1d-d0a93deaae3a



