### PR TITLE
fix(size-store-sync): do not sync size in favor of customizability

### DIFF
--- a/packages/angular-library/projects/components/src/lib/stencil-generated/components.ts
+++ b/packages/angular-library/projects/components/src/lib/stencil-generated/components.ts
@@ -3655,14 +3655,14 @@ export declare interface RtkTranscripts extends Components.RtkTranscripts {}
 
 
 @ProxyCmp({
-  inputs: ['config', 'iconPack', 'meeting', 'mode', 'showSetupScreen', 'size', 't']
+  inputs: ['config', 'iconPack', 'meeting', 'mode', 'showSetupScreen', 't']
 })
 @Component({
   selector: 'rtk-ui-provider',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['config', 'iconPack', 'meeting', 'mode', 'showSetupScreen', 'size', 't'],
+  inputs: ['config', 'iconPack', 'meeting', 'mode', 'showSetupScreen', 't'],
 })
 export class RtkUiProvider {
   protected el: HTMLRtkUiProviderElement;

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -3884,10 +3884,6 @@ export namespace Components {
          */
         "showSetupScreen": boolean;
         /**
-          * Size
-         */
-        "size": Size1;
-        /**
           * Language utility
          */
         "t": RtkI18n1;
@@ -10813,10 +10809,6 @@ declare namespace LocalJSX {
           * Whether to show setup screen or not
          */
         "showSetupScreen"?: boolean;
-        /**
-          * Size
-         */
-        "size"?: Size1;
         /**
           * Language utility
          */

--- a/packages/core/src/components/rtk-ai-toggle/rtk-ai-toggle.tsx
+++ b/packages/core/src/components/rtk-ai-toggle/rtk-ai-toggle.tsx
@@ -27,7 +27,7 @@ export class RtkAiToggle {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-ai/rtk-ai.tsx
+++ b/packages/core/src/components/rtk-ai/rtk-ai.tsx
@@ -44,7 +44,7 @@ export class RtkAi {
   t: RtkI18n = useLanguage();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** View type */
   @Prop({ reflect: true }) view: AIView = 'sidebar';

--- a/packages/core/src/components/rtk-audio-grid/rtk-audio-grid.tsx
+++ b/packages/core/src/components/rtk-audio-grid/rtk-audio-grid.tsx
@@ -39,7 +39,7 @@ export class RtkAudioGrid {
   iconPack: IconPack = defaultIconPack;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Language */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-audio-tile/rtk-audio-tile.tsx
+++ b/packages/core/src/components/rtk-audio-tile/rtk-audio-tile.tsx
@@ -26,7 +26,7 @@ export class RtkAudioTile {
   config: UIConfig;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** States */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-audio-visualizer/rtk-audio-visualizer.tsx
+++ b/packages/core/src/components/rtk-audio-visualizer/rtk-audio-visualizer.tsx
@@ -36,7 +36,7 @@ export class RtkAudioVisualizer {
   @Prop() participant: Peer;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-avatar/rtk-avatar.tsx
+++ b/packages/core/src/components/rtk-avatar/rtk-avatar.tsx
@@ -24,7 +24,7 @@ export class RtkAvatar {
   @Prop({ reflect: true }) variant: AvatarVariant = 'circular';
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-breakout-room-toggle/rtk-breakout-rooms-toggle.tsx
+++ b/packages/core/src/components/rtk-breakout-room-toggle/rtk-breakout-rooms-toggle.tsx
@@ -32,7 +32,7 @@ export class RtkBreakoutRoomsToggle {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-button/rtk-button.tsx
+++ b/packages/core/src/components/rtk-button/rtk-button.tsx
@@ -1,6 +1,5 @@
 import { Size } from '../../types/props';
 import { Component, Host, h, Prop } from '@stencil/core';
-import { SyncWithStore } from '../../utils/sync-with-store';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost';
 
@@ -20,7 +19,7 @@ export type ButtonKind = 'button' | 'icon' | 'wide';
 })
 export class RtkButton {
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Button variant */
   @Prop({ reflect: true }) variant: ButtonVariant = 'primary';

--- a/packages/core/src/components/rtk-camera-selector/rtk-camera-selector.tsx
+++ b/packages/core/src/components/rtk-camera-selector/rtk-camera-selector.tsx
@@ -29,7 +29,7 @@ export class RtkCameraSelector {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-camera-toggle/rtk-camera-toggle.tsx
+++ b/packages/core/src/components/rtk-camera-toggle/rtk-camera-toggle.tsx
@@ -48,7 +48,7 @@ export class RtkCameraToggle {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-caption-toggle/rtk-caption-toggle.tsx
+++ b/packages/core/src/components/rtk-caption-toggle/rtk-caption-toggle.tsx
@@ -43,7 +43,7 @@ export class RtkCaptionToggle {
   iconPack: IconPack = defaultIconPack;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Language */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-chat-composer-ui/rtk-chat-composer-ui.tsx
+++ b/packages/core/src/components/rtk-chat-composer-ui/rtk-chat-composer-ui.tsx
@@ -56,7 +56,7 @@ export class RtkChatComposerUi {
   @Prop() canSendFiles = false;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-chat-message/rtk-chat-message.tsx
+++ b/packages/core/src/components/rtk-chat-message/rtk-chat-message.tsx
@@ -34,7 +34,7 @@ export class RtkChatMessage {
   @Prop() isUnread: boolean;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-chat-messages-ui-paginated/rtk-chat-messages-ui-paginated.tsx
+++ b/packages/core/src/components/rtk-chat-messages-ui-paginated/rtk-chat-messages-ui-paginated.tsx
@@ -42,7 +42,7 @@ export class RtkChatMessagesUiPaginated {
   @Prop() selectedChannelId?: string;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-chat-messages-ui/rtk-chat-messages-ui.tsx
+++ b/packages/core/src/components/rtk-chat-messages-ui/rtk-chat-messages-ui.tsx
@@ -49,7 +49,7 @@ export class RtkChatMessagesUi {
   @Prop() canPinMessages: boolean = false;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
+++ b/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
@@ -41,7 +41,7 @@ export class RtkChatToggle {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-chat/rtk-chat.tsx
+++ b/packages/core/src/components/rtk-chat/rtk-chat.tsx
@@ -73,7 +73,7 @@ export class RtkChat {
   config: UIConfig = createDefaultConfig();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-controlbar-button/rtk-controlbar-button.tsx
+++ b/packages/core/src/components/rtk-controlbar-button/rtk-controlbar-button.tsx
@@ -21,7 +21,7 @@ export class RtkControlbarButton {
   @Prop() showWarning: boolean = false;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Label of button */
   @Prop() label: string;

--- a/packages/core/src/components/rtk-controlbar/rtk-controlbar.tsx
+++ b/packages/core/src/components/rtk-controlbar/rtk-controlbar.tsx
@@ -49,7 +49,7 @@ export class RtkControlbar {
   t: RtkI18n = useLanguage();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   render() {
     const defaults = {

--- a/packages/core/src/components/rtk-counter/rtk-counter.tsx
+++ b/packages/core/src/components/rtk-counter/rtk-counter.tsx
@@ -16,7 +16,7 @@ export class RtkCounter {
   @State() input: string = '1';
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Initial value */
   @Prop() value: number;

--- a/packages/core/src/components/rtk-debugger-audio/rtk-debugger-audio.tsx
+++ b/packages/core/src/components/rtk-debugger-audio/rtk-debugger-audio.tsx
@@ -31,7 +31,7 @@ export class RtkDebuggerAudio {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-debugger-screenshare/rtk-debugger-screenshare.tsx
+++ b/packages/core/src/components/rtk-debugger-screenshare/rtk-debugger-screenshare.tsx
@@ -37,7 +37,7 @@ export class RtkDebuggerScreenShare {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-debugger-system/rtk-debugger-system.tsx
+++ b/packages/core/src/components/rtk-debugger-system/rtk-debugger-system.tsx
@@ -44,7 +44,7 @@ export class RtkDebuggerSystem {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-debugger-toggle/rtk-debugger-toggle.tsx
+++ b/packages/core/src/components/rtk-debugger-toggle/rtk-debugger-toggle.tsx
@@ -39,7 +39,7 @@ export class RtkDebuggerToggle {
   @Event({ eventName: 'rtkStateUpdate' }) stateUpdate: EventEmitter<States>;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   private toggleDebugger() {
     this.stateUpdate.emit({

--- a/packages/core/src/components/rtk-debugger-video/rtk-debugger-video.tsx
+++ b/packages/core/src/components/rtk-debugger-video/rtk-debugger-video.tsx
@@ -31,7 +31,7 @@ export class RtkDebuggerVideo {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-debugger/rtk-debugger.tsx
+++ b/packages/core/src/components/rtk-debugger/rtk-debugger.tsx
@@ -32,7 +32,7 @@ export class RtkDebugger {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-dialog-manager/rtk-dialog-manager.tsx
+++ b/packages/core/src/components/rtk-dialog-manager/rtk-dialog-manager.tsx
@@ -41,7 +41,7 @@ export class RtkDialogManager {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-dialog/rtk-dialog.tsx
+++ b/packages/core/src/components/rtk-dialog/rtk-dialog.tsx
@@ -38,7 +38,7 @@ export class RtkDialog {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-ended-screen/rtk-ended-screen.tsx
+++ b/packages/core/src/components/rtk-ended-screen/rtk-ended-screen.tsx
@@ -22,7 +22,7 @@ export class RtkEndedScreen {
   config: UIConfig = createDefaultConfig();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon */
   @State() icon: IconPack = defaultIconPack;

--- a/packages/core/src/components/rtk-fullscreen-toggle/rtk-fullscreen-toggle.tsx
+++ b/packages/core/src/components/rtk-fullscreen-toggle/rtk-fullscreen-toggle.tsx
@@ -33,7 +33,7 @@ export class RtkFullscreenToggle {
   @Prop({ reflect: true }) variant: ControlBarVariant = 'button';
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-grid-pagination/rtk-grid-pagination.tsx
+++ b/packages/core/src/components/rtk-grid-pagination/rtk-grid-pagination.tsx
@@ -32,7 +32,7 @@ export class RtkGridPagination {
   states: States;
 
   /** Size Prop */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Variant */
   @Prop({ reflect: true }) variant: GridPaginationVariants = 'rounded';

--- a/packages/core/src/components/rtk-grid/rtk-grid.tsx
+++ b/packages/core/src/components/rtk-grid/rtk-grid.tsx
@@ -71,7 +71,7 @@ export class RtkGrid {
   @Prop({ reflect: true }) gap: number = 8;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** States */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-header/rtk-header.tsx
+++ b/packages/core/src/components/rtk-header/rtk-header.tsx
@@ -49,7 +49,7 @@ export class RtkHeader {
   t: RtkI18n = useLanguage();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   render() {
     const defaults = {

--- a/packages/core/src/components/rtk-icon/rtk-icon.tsx
+++ b/packages/core/src/components/rtk-icon/rtk-icon.tsx
@@ -1,6 +1,5 @@
 import { Component, Host, h, Prop } from '@stencil/core';
 import { Size } from '../../exports';
-import { SyncWithStore } from '../../utils/sync-with-store';
 
 const parseIcon = (icon: string) => {
   try {
@@ -28,7 +27,7 @@ export class RtkIcon {
   @Prop({ reflect: true }) variant: IconVariant = 'primary';
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size = 'lg';
+  @Prop({ reflect: true }) size: Size = 'lg';
 
   render() {
     return (

--- a/packages/core/src/components/rtk-image-viewer/rtk-image-viewer.tsx
+++ b/packages/core/src/components/rtk-image-viewer/rtk-image-viewer.tsx
@@ -20,7 +20,7 @@ export class RtkImageViewer {
   @Prop() image!: ImageMessage;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Language */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-join-stage/rtk-join-stage.tsx
+++ b/packages/core/src/components/rtk-join-stage/rtk-join-stage.tsx
@@ -39,7 +39,7 @@ export class RtkJoinStage {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-leave-button/rtk-leave-button.tsx
+++ b/packages/core/src/components/rtk-leave-button/rtk-leave-button.tsx
@@ -18,7 +18,7 @@ export class RtkLeaveButton {
   @Prop({ reflect: true }) variant: ControlBarVariant = 'button';
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-livestream-indicator/rtk-livestream-indicator.tsx
+++ b/packages/core/src/components/rtk-livestream-indicator/rtk-livestream-indicator.tsx
@@ -18,7 +18,7 @@ export class RtkLivestreamIndicator {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Language */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-livestream-player/rtk-livestream-player.tsx
+++ b/packages/core/src/components/rtk-livestream-player/rtk-livestream-player.tsx
@@ -45,7 +45,7 @@ export class RtkLivestreamPlayer {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Language */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-livestream-toggle/rtk-livestream-toggle.tsx
+++ b/packages/core/src/components/rtk-livestream-toggle/rtk-livestream-toggle.tsx
@@ -23,7 +23,7 @@ export class RtkLivestreamToggle {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-meeting/rtk-meeting.tsx
+++ b/packages/core/src/components/rtk-meeting/rtk-meeting.tsx
@@ -150,7 +150,6 @@ export class RtkMeeting {
     this.iconPackChanged(this.iconPack);
     this.tChanged(this.t);
     this.configChanged(this.config);
-    this.sizeChanged(this.size);
 
     this.resizeObserver = new ResizeObserver(() => this.handleResize());
     this.resizeObserver.observe(this.host);
@@ -251,7 +250,6 @@ export class RtkMeeting {
         config: this.config,
         iconPack: this.iconPack,
         t: this.t,
-        size: this.size,
         providerId: this.providerId,
       }) as RtkUiStoreExtended;
 
@@ -340,13 +338,6 @@ export class RtkMeeting {
   tChanged(newT: RtkI18n) {
     if (this.peerStore) {
       this.peerStore.state.t = newT;
-    }
-  }
-
-  @Watch('size')
-  sizeChanged(newSize: Size) {
-    if (this.peerStore) {
-      this.peerStore.state.size = newSize;
     }
   }
 

--- a/packages/core/src/components/rtk-menu-item/rtk-menu-item.tsx
+++ b/packages/core/src/components/rtk-menu-item/rtk-menu-item.tsx
@@ -18,7 +18,7 @@ import { useLanguage, RtkI18n } from '../../lib/lang';
 })
 export class RtkMenuItem {
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-menu/rtk-menu.tsx
+++ b/packages/core/src/components/rtk-menu/rtk-menu.tsx
@@ -24,7 +24,7 @@ export class RtkMenu {
   private clickedThis: boolean = false;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Placement of menu */
   @Prop() placement: Placement = 'bottom-end';

--- a/packages/core/src/components/rtk-mic-toggle/rtk-mic-toggle.tsx
+++ b/packages/core/src/components/rtk-mic-toggle/rtk-mic-toggle.tsx
@@ -48,7 +48,7 @@ export class RtkMicToggle {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-microphone-selector/rtk-microphone-selector.tsx
+++ b/packages/core/src/components/rtk-microphone-selector/rtk-microphone-selector.tsx
@@ -30,7 +30,7 @@ export class RtkMicrophoneSelector {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-mixed-grid/rtk-mixed-grid.tsx
+++ b/packages/core/src/components/rtk-mixed-grid/rtk-mixed-grid.tsx
@@ -50,7 +50,7 @@ export class RtkMixedGrid {
   @Prop() gap: number = 8;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Meeting object */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-more-toggle/rtk-more-toggle.tsx
+++ b/packages/core/src/components/rtk-more-toggle/rtk-more-toggle.tsx
@@ -26,7 +26,7 @@ export class RtkMoreToggle {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-mute-all-button/rtk-mute-all-button.tsx
+++ b/packages/core/src/components/rtk-mute-all-button/rtk-mute-all-button.tsx
@@ -20,7 +20,7 @@ export class RtkMuteAllButton {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-name-tag/rtk-name-tag.tsx
+++ b/packages/core/src/components/rtk-name-tag/rtk-name-tag.tsx
@@ -26,7 +26,7 @@ export class RtkNameTag {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Whether it is used in a screen share view */
   @Prop() isScreenShare: boolean = false;

--- a/packages/core/src/components/rtk-notification/rtk-notification.tsx
+++ b/packages/core/src/components/rtk-notification/rtk-notification.tsx
@@ -24,7 +24,7 @@ export class RtkNotification {
   @Prop() paused: boolean;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-notifications/rtk-notifications.tsx
+++ b/packages/core/src/components/rtk-notifications/rtk-notifications.tsx
@@ -104,7 +104,7 @@ export class RtkNotifications {
   t: RtkI18n = useLanguage();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-participant-count/rtk-participant-count.tsx
+++ b/packages/core/src/components/rtk-participant-count/rtk-participant-count.tsx
@@ -35,7 +35,7 @@ export class RtkParticipantCount {
   t: RtkI18n = useLanguage();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   @State() participantCount: number = 0;
 

--- a/packages/core/src/components/rtk-participant-setup/rtk-participant-setup.tsx
+++ b/packages/core/src/components/rtk-participant-setup/rtk-participant-setup.tsx
@@ -51,7 +51,7 @@ export class RtkParticipantSetup {
   @Prop({ reflect: true }) variant: 'solid' | 'gradient' = 'solid';
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-participant-tile/rtk-participant-tile.tsx
+++ b/packages/core/src/components/rtk-participant-tile/rtk-participant-tile.tsx
@@ -62,7 +62,7 @@ export class RtkParticipantTile {
   @Prop({ reflect: true }) variant: 'solid' | 'gradient' = 'solid';
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-participants-stage-list/rtk-participants-stage-list.tsx
+++ b/packages/core/src/components/rtk-participants-stage-list/rtk-participants-stage-list.tsx
@@ -38,7 +38,7 @@ export class RtkParticipants {
   config: UIConfig = createDefaultConfig();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Hide Stage Participants Count Header */
   @Prop() hideHeader: boolean = false;

--- a/packages/core/src/components/rtk-participants-stage-queue/rtk-participants-stage-queue.tsx
+++ b/packages/core/src/components/rtk-participants-stage-queue/rtk-participants-stage-queue.tsx
@@ -29,7 +29,7 @@ export class RtkParticipantsStaged {
   config: UIConfig = createDefaultConfig();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-participants-toggle/rtk-participants-toggle.tsx
+++ b/packages/core/src/components/rtk-participants-toggle/rtk-participants-toggle.tsx
@@ -39,7 +39,7 @@ export class RtkParticipantsToggle {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-participants-viewer-list/rtk-participants-viewer-list.tsx
+++ b/packages/core/src/components/rtk-participants-viewer-list/rtk-participants-viewer-list.tsx
@@ -35,7 +35,7 @@ export class RtkParticipantsViewers {
   config: UIConfig = createDefaultConfig();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Hide Viewer Count Header */
   @Prop() hideHeader: boolean = false;

--- a/packages/core/src/components/rtk-participants-waiting-list/rtk-participants-waiting-list.tsx
+++ b/packages/core/src/components/rtk-participants-waiting-list/rtk-participants-waiting-list.tsx
@@ -32,7 +32,7 @@ export class RtkParticipantsWaitlisted {
   config: UIConfig = createDefaultConfig();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-participants/rtk-participants.tsx
+++ b/packages/core/src/components/rtk-participants/rtk-participants.tsx
@@ -43,7 +43,7 @@ export class RtkParticipants {
   config: UIConfig = createDefaultConfig();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-pip-toggle/rtk-pip-toggle.tsx
+++ b/packages/core/src/components/rtk-pip-toggle/rtk-pip-toggle.tsx
@@ -42,7 +42,7 @@ export class RtkPipToggle {
   iconPack: IconPack = defaultIconPack;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Language */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-plugins-toggle/rtk-plugins-toggle.tsx
+++ b/packages/core/src/components/rtk-plugins-toggle/rtk-plugins-toggle.tsx
@@ -36,7 +36,7 @@ export class RtkPluginsToggle {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-plugins/rtk-plugins.tsx
+++ b/packages/core/src/components/rtk-plugins/rtk-plugins.tsx
@@ -30,7 +30,7 @@ export class RtkPlugins {
   config: UIConfig = createDefaultConfig();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-polls-toggle/rtk-polls-toggle.tsx
+++ b/packages/core/src/components/rtk-polls-toggle/rtk-polls-toggle.tsx
@@ -38,7 +38,7 @@ export class RtkPollsToggle {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-polls/rtk-polls.tsx
+++ b/packages/core/src/components/rtk-polls/rtk-polls.tsx
@@ -34,7 +34,7 @@ export class RtkPolls {
   config: UIConfig = createDefaultConfig();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-recording-indicator/rtk-recording-indicator.tsx
+++ b/packages/core/src/components/rtk-recording-indicator/rtk-recording-indicator.tsx
@@ -25,7 +25,7 @@ export class RtkRecordingIndicator {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Language */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-recording-toggle/rtk-recording-toggle.tsx
+++ b/packages/core/src/components/rtk-recording-toggle/rtk-recording-toggle.tsx
@@ -41,7 +41,7 @@ export class RtkRecordingToggle {
   iconPack: IconPack = defaultIconPack;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Disable the button */
   @Prop() disabled: boolean = false;

--- a/packages/core/src/components/rtk-screen-share-toggle/rtk-screen-share-toggle.tsx
+++ b/packages/core/src/components/rtk-screen-share-toggle/rtk-screen-share-toggle.tsx
@@ -50,7 +50,7 @@ export class RtkScreenShareToggle {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-screenshare-view/rtk-screenshare-view.tsx
+++ b/packages/core/src/components/rtk-screenshare-view/rtk-screenshare-view.tsx
@@ -76,7 +76,7 @@ export class RtkScreenshareView {
   @Prop({ reflect: true }) variant: 'solid' | 'gradient' = 'solid';
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-settings-audio/rtk-settings-audio.tsx
+++ b/packages/core/src/components/rtk-settings-audio/rtk-settings-audio.tsx
@@ -35,7 +35,7 @@ export class RtkSettingsAudio {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-settings-toggle/rtk-settings-toggle.tsx
+++ b/packages/core/src/components/rtk-settings-toggle/rtk-settings-toggle.tsx
@@ -29,7 +29,7 @@ export class RtkSettingsToggle {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-settings-video/rtk-settings-video.tsx
+++ b/packages/core/src/components/rtk-settings-video/rtk-settings-video.tsx
@@ -35,7 +35,7 @@ export class RtkSettingsVideo {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-settings/rtk-settings.tsx
+++ b/packages/core/src/components/rtk-settings/rtk-settings.tsx
@@ -39,7 +39,7 @@ export class RtkSettings {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.tsx
+++ b/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.tsx
@@ -43,7 +43,7 @@ export class RtkSetupScreen {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Config object */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-sidebar/rtk-sidebar.tsx
+++ b/packages/core/src/components/rtk-sidebar/rtk-sidebar.tsx
@@ -62,7 +62,7 @@ export class RtkSidebar {
   t: RtkI18n = useLanguage();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** View type */
   @Prop({ reflect: true }) view: RtkSidebarView = 'sidebar';

--- a/packages/core/src/components/rtk-simple-grid/rtk-simple-grid.tsx
+++ b/packages/core/src/components/rtk-simple-grid/rtk-simple-grid.tsx
@@ -36,7 +36,7 @@ export class RtkSimpleGrid {
   @Prop() gap: number = 8;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Meeting object */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-speaker-selector/rtk-speaker-selector.tsx
+++ b/packages/core/src/components/rtk-speaker-selector/rtk-speaker-selector.tsx
@@ -42,7 +42,7 @@ export class RtkSpeakerSelector {
   @Prop() variant: 'full' | 'inline' = 'full';
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-spinner/rtk-spinner.tsx
+++ b/packages/core/src/components/rtk-spinner/rtk-spinner.tsx
@@ -18,7 +18,7 @@ export class RtkSpinner {
   iconPack: IconPack = defaultIconPack;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size = 'md';
+  @Prop({ reflect: true }) size: Size = 'md';
 
   render() {
     return (

--- a/packages/core/src/components/rtk-spotlight-grid/rtk-spotlight-grid.tsx
+++ b/packages/core/src/components/rtk-spotlight-grid/rtk-spotlight-grid.tsx
@@ -44,7 +44,7 @@ export class RtkSpotlightGrid {
   @Prop() gap: number = 8;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Meeting object */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-spotlight-indicator/rtk-spotlight-indicator.tsx
+++ b/packages/core/src/components/rtk-spotlight-indicator/rtk-spotlight-indicator.tsx
@@ -27,7 +27,7 @@ export class RtkSpotlightIndicator {
   t: RtkI18n = useLanguage();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   @State() canSpotlight: boolean;
 

--- a/packages/core/src/components/rtk-stage-toggle/rtk-stage-toggle.tsx
+++ b/packages/core/src/components/rtk-stage-toggle/rtk-stage-toggle.tsx
@@ -28,7 +28,7 @@ export class RtkStageToggle {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-tab-bar/rtk-tab-bar.tsx
+++ b/packages/core/src/components/rtk-tab-bar/rtk-tab-bar.tsx
@@ -24,7 +24,7 @@ export interface Tab {
 })
 export class RtkTabBar {
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Meeting object */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-tooltip/rtk-tooltip.tsx
+++ b/packages/core/src/components/rtk-tooltip/rtk-tooltip.tsx
@@ -12,7 +12,6 @@ import {
 import { arrow, computePosition, flip, offset, shift } from '@floating-ui/dom';
 import { Size } from '../../types/props';
 import { Placement } from '../../types/floating-ui';
-import { SyncWithStore } from '../../utils/sync-with-store';
 
 export type TooltipVariant = 'primary' | 'secondary';
 export type TooltipKind = 'inline' | 'block';
@@ -49,7 +48,7 @@ export class RtkMenu {
   @Prop({ reflect: true }) kind: TooltipKind = 'inline';
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Placement of menu */
   @Prop() placement: Placement = 'top';

--- a/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
+++ b/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
@@ -5,7 +5,6 @@ import {
   createDefaultConfig,
   RtkI18n,
   IconPack,
-  Size,
   States,
   UIConfig,
   useLanguage,
@@ -19,7 +18,6 @@ import {
 } from '../../utils/sync-with-store/ui-store';
 import deepMerge from 'lodash-es/merge';
 import { PermissionSettings } from '../../types/props';
-import { getSize } from '../../utils/size';
 
 const LEAVE_ROOM_TIMER = 10000;
 
@@ -55,9 +53,6 @@ export class RtkUiProvider {
   /** Fill type */
   @Prop({ reflect: true }) mode: MeetingMode = 'fixed';
 
-  /** Size */
-  @Prop({ reflect: true, mutable: true }) size: Size;
-
   /** Whether to show setup screen or not */
   @Prop() showSetupScreen: boolean = false;
 
@@ -68,8 +63,6 @@ export class RtkUiProvider {
   @Event({ eventName: 'rtkStatesUpdate' }) statesUpdate: EventEmitter<States>;
 
   private authErrorListener: (ev: CustomEvent<Error>) => void;
-
-  private resizeObserver: ResizeObserver;
 
   connectedCallback() {
     if (typeof window !== 'undefined') {
@@ -88,14 +81,9 @@ export class RtkUiProvider {
     this.iconPackChanged(this.iconPack);
     this.tChanged(this.t);
     this.configChanged(this.config);
-    this.sizeChanged(this.size);
-
-    this.resizeObserver = new ResizeObserver(() => this.handleResize());
-    this.resizeObserver.observe(this.host);
   }
 
   disconnectedCallback() {
-    this.resizeObserver.disconnect();
     window.removeEventListener('rtkError', this.authErrorListener);
 
     // Remove event listeners
@@ -180,7 +168,6 @@ export class RtkUiProvider {
         config: this.config,
         iconPack: this.iconPack,
         t: this.t,
-        size: this.size,
         providerId: this.providerId,
       }) as RtkUiStoreExtended;
 
@@ -255,17 +242,6 @@ export class RtkUiProvider {
       provideRtkDesignSystem(document.documentElement, config.designTokens);
     }
   }
-
-  @Watch('size')
-  sizeChanged(newSize: Size) {
-    if (this.peerStore) {
-      this.peerStore.state.size = newSize;
-    }
-  }
-
-  private handleResize = () => {
-    this.size = getSize(this.host.clientWidth);
-  };
 
   private roomJoinedListener = () => {
     this.updateStates({ meeting: 'joined' });

--- a/packages/core/src/utils/sync-with-store/ui-store.ts
+++ b/packages/core/src/utils/sync-with-store/ui-store.ts
@@ -5,7 +5,6 @@ import { defaultIconPack, type IconPack } from '../../lib/icons';
 import { type States } from '../../types/props';
 import { getUserPreferences } from '../user-prefs';
 import { createDefaultConfig, UIConfig } from '../../exports';
-import { Size } from '../../exports';
 
 export const getInitialStates = (peerId?: string): States => ({
   meeting: 'idle',
@@ -19,7 +18,6 @@ export interface RtkUiStore {
   iconPack: IconPack;
   states: States;
   config: UIConfig;
-  size: Size | undefined;
   peerId: string | null;
   storeType: 'global' | 'peer';
   storeId: string;
@@ -36,7 +34,6 @@ const uiStore = createStore<RtkUiStore>({
   iconPack: defaultIconPack,
   states: getInitialStates(),
   config: createDefaultConfig(),
-  size: undefined,
   peerId: 'global',
   storeType: 'global',
   storeId: 'store-global',
@@ -77,15 +74,13 @@ export function createPeerStore({
   config,
   providerId,
   iconPack,
-  t,
-  size
+  t
 }: {
   meeting: RealtimeKitClient;
   config?: UIConfig;
   providerId: string;
   iconPack: IconPack;
   t: RtkI18n;
-  size: Size | undefined;
 }): RtkUiStoreExtended {
   const store = createStore<RtkUiStore>({
     meeting: meeting,
@@ -93,7 +88,6 @@ export function createPeerStore({
     iconPack,
     states: getInitialStates(meeting.self.peerId),
     config: config || createDefaultConfig(),
-    size,
     peerId: meeting.self.id,
     storeType: 'peer',
     // Use provider id's numeric portion as store id for easier debugging


### PR DESCRIPTION
### Description

1. No longer Syncing size with Store. Letting rtk-meeting or user or a HOC component manage it.
2. Since rtk-ui-provider only has a slot. Removed resize observer from it as we are no longer syncing size in store so it is not needed.