### PR TITLE
chore(release): per page multi meeting support, enhanced rtk-ui-provider for custom ui implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.0.4-staging.2](https://github.com/dyte-io/realtimekit-ui/compare/@cloudflare/realtimekit-ui-v1.0.4-staging.1...@cloudflare/realtimekit-ui-v1.0.4-staging.2) (2025-07-24)
+
+
+### Bug Fixes
+
+* **angular:** module fields in package.json ([#34](https://github.com/dyte-io/realtimekit-ui/issues/34)) ([2d3da98](https://github.com/dyte-io/realtimekit-ui/commit/2d3da98c61c28bcc07acfd55981a4d2416cda072))
+
 ## [1.0.4-staging.1](https://github.com/dyte-io/realtimekit-ui/compare/@cloudflare/realtimekit-ui-v1.0.3...@cloudflare/realtimekit-ui-v1.0.4-staging.1) (2025-07-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.0.4-staging.4](https://github.com/dyte-io/realtimekit-ui/compare/@cloudflare/realtimekit-ui-v1.0.4-staging.3...@cloudflare/realtimekit-ui-v1.0.4-staging.4) (2025-07-25)
+
+
+### Bug Fixes
+
+* **store-sync-issues:** in some cases, rtk-meeting was not syncing its state with peer store ([#36](https://github.com/dyte-io/realtimekit-ui/issues/36)) ([a447a73](https://github.com/dyte-io/realtimekit-ui/commit/a447a739a6dbc23949d1f7e6eff1cc5cea07ca15))
+
 ## [1.0.4-staging.3](https://github.com/dyte-io/realtimekit-ui/compare/@cloudflare/realtimekit-ui-v1.0.4-staging.2...@cloudflare/realtimekit-ui-v1.0.4-staging.3) (2025-07-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.0.4-staging.5](https://github.com/dyte-io/realtimekit-ui/compare/@cloudflare/realtimekit-ui-v1.0.4-staging.4...@cloudflare/realtimekit-ui-v1.0.4-staging.5) (2025-07-29)
+
+
+### Bug Fixes
+
+* **size-store-sync:** do not sync size in favor of customizability ([#39](https://github.com/dyte-io/realtimekit-ui/issues/39)) ([7604824](https://github.com/dyte-io/realtimekit-ui/commit/760482489bbb4832928cf85ee01a91a4c5d70c1e))
+
 ## [1.0.4-staging.4](https://github.com/dyte-io/realtimekit-ui/compare/@cloudflare/realtimekit-ui-v1.0.4-staging.3...@cloudflare/realtimekit-ui-v1.0.4-staging.4) (2025-07-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.0.4-staging.3](https://github.com/dyte-io/realtimekit-ui/compare/@cloudflare/realtimekit-ui-v1.0.4-staging.2...@cloudflare/realtimekit-ui-v1.0.4-staging.3) (2025-07-25)
+
+
+### Bug Fixes
+
+* **double-listener-execution:** listeners for chat, participant joins were registered  twice ([#35](https://github.com/dyte-io/realtimekit-ui/issues/35)) ([c2ba49f](https://github.com/dyte-io/realtimekit-ui/commit/c2ba49f6b1d1e741d90f3172c35eb25bc00f06bc))
+
 ## [1.0.4-staging.2](https://github.com/dyte-io/realtimekit-ui/compare/@cloudflare/realtimekit-ui-v1.0.4-staging.1...@cloudflare/realtimekit-ui-v1.0.4-staging.2) (2025-07-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.0.4-staging.1](https://github.com/dyte-io/realtimekit-ui/compare/@cloudflare/realtimekit-ui-v1.0.3...@cloudflare/realtimekit-ui-v1.0.4-staging.1) (2025-07-17)
+
+
+### Bug Fixes
+
+* **singletons:** Removed UI Kit Singletons to support multiple meeting on a single page ([#27](https://github.com/dyte-io/realtimekit-ui/issues/27)) ([1793c22](https://github.com/dyte-io/realtimekit-ui/commit/1793c22ed7d01afa6c8e76641b49f96bd851150f))
+
 ## [1.0.3](https://github.com/dyte-io/realtimekit-ui/compare/@cloudflare/realtimekit-ui-v1.0.2...@cloudflare/realtimekit-ui-v1.0.3) (2025-07-17)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32557,7 +32557,7 @@
     },
     "packages/core": {
       "name": "@cloudflare/realtimekit-ui",
-      "version": "1.0.4-staging.3",
+      "version": "1.0.4-staging.4",
       "license": "UNLICENSED",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
@@ -32617,7 +32617,7 @@
     },
     "packages/react-library": {
       "name": "@cloudflare/realtimekit-react-ui",
-      "version": "1.0.4-staging.3",
+      "version": "1.0.4-staging.4",
       "license": "UNLICENSED",
       "dependencies": {
         "@cloudflare/realtimekit-ui": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -32557,7 +32557,7 @@
     },
     "packages/core": {
       "name": "@cloudflare/realtimekit-ui",
-      "version": "1.0.4-staging.1",
+      "version": "1.0.4-staging.2",
       "license": "UNLICENSED",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
@@ -32617,7 +32617,7 @@
     },
     "packages/react-library": {
       "name": "@cloudflare/realtimekit-react-ui",
-      "version": "1.0.4-staging.1",
+      "version": "1.0.4-staging.2",
       "license": "UNLICENSED",
       "dependencies": {
         "@cloudflare/realtimekit-ui": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -32557,7 +32557,7 @@
     },
     "packages/core": {
       "name": "@cloudflare/realtimekit-ui",
-      "version": "1.0.3",
+      "version": "1.0.4-staging.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
@@ -32617,7 +32617,7 @@
     },
     "packages/react-library": {
       "name": "@cloudflare/realtimekit-react-ui",
-      "version": "1.0.3",
+      "version": "1.0.4-staging.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@cloudflare/realtimekit-ui": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -32557,7 +32557,7 @@
     },
     "packages/core": {
       "name": "@cloudflare/realtimekit-ui",
-      "version": "1.0.4-staging.4",
+      "version": "1.0.4-staging.5",
       "license": "UNLICENSED",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
@@ -32617,7 +32617,7 @@
     },
     "packages/react-library": {
       "name": "@cloudflare/realtimekit-react-ui",
-      "version": "1.0.4-staging.4",
+      "version": "1.0.4-staging.5",
       "license": "UNLICENSED",
       "dependencies": {
         "@cloudflare/realtimekit-ui": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -32557,7 +32557,7 @@
     },
     "packages/core": {
       "name": "@cloudflare/realtimekit-ui",
-      "version": "1.0.4-staging.2",
+      "version": "1.0.4-staging.3",
       "license": "UNLICENSED",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
@@ -32617,7 +32617,7 @@
     },
     "packages/react-library": {
       "name": "@cloudflare/realtimekit-react-ui",
-      "version": "1.0.4-staging.2",
+      "version": "1.0.4-staging.3",
       "license": "UNLICENSED",
       "dependencies": {
         "@cloudflare/realtimekit-ui": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2063,19 +2063,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@cloudflare/realtimekit": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@cloudflare/realtimekit/-/realtimekit-1.1.2.tgz",
-      "integrity": "sha512-aJHTGSFmlir/t0rn6xYQ2Q4beD2cPeAqeFfjvSmvInds/W1f0IW4hHAoqBSygQRYUmKkGQBWpqLvx8PeissMNw==",
-      "dev": true,
-      "dependencies": {
-        "@protobuf-ts/runtime": "^2.7.0",
-        "bowser": "^2.11.0",
-        "sdp-transform": "^2.14.1",
-        "uuid": "^8.3.2",
-        "worker-timers": "7.0.60"
-      }
-    },
     "node_modules/@cloudflare/realtimekit-angular-ui": {
       "resolved": "packages/angular-library",
       "link": true
@@ -32606,6 +32593,19 @@
         "rollup": "^4.32.1",
         "rollup-plugin-node-polyfills": "^0.2.1",
         "tailwindcss": "3.1.0"
+      }
+    },
+    "packages/core/node_modules/@cloudflare/realtimekit": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/realtimekit/-/realtimekit-1.1.2.tgz",
+      "integrity": "sha512-aJHTGSFmlir/t0rn6xYQ2Q4beD2cPeAqeFfjvSmvInds/W1f0IW4hHAoqBSygQRYUmKkGQBWpqLvx8PeissMNw==",
+      "dev": true,
+      "dependencies": {
+        "@protobuf-ts/runtime": "^2.7.0",
+        "bowser": "^2.11.0",
+        "sdp-transform": "^2.14.1",
+        "uuid": "^8.3.2",
+        "worker-timers": "7.0.60"
       }
     },
     "packages/core/node_modules/@types/node": {

--- a/packages/angular-library/projects/components/package.json
+++ b/packages/angular-library/projects/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/realtimekit-angular-ui",
-  "version": "1.0.3",
+  "version": "1.0.4-staging.1",
   "description": "Pre-built, ready-to-use Angular UI components and utilities for integrating with Cloudflare RealtimeKit",
   "peerDependencies": {
     "@angular/common": ">=12",

--- a/packages/angular-library/projects/components/package.json
+++ b/packages/angular-library/projects/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/realtimekit-angular-ui",
-  "version": "1.0.4-staging.3",
+  "version": "1.0.4-staging.4",
   "description": "Pre-built, ready-to-use Angular UI components and utilities for integrating with Cloudflare RealtimeKit",
   "peerDependencies": {
     "@angular/common": ">=12",

--- a/packages/angular-library/projects/components/package.json
+++ b/packages/angular-library/projects/components/package.json
@@ -23,9 +23,26 @@
     "postpublish": "mv package.json.bak package.json"
   },
   "module": "dist/fesm2022/cloudflare-realtimekit-angular-ui.mjs",
-  "typings": "dist/index.d.ts",
+  "typings": "dist/cloudflare-realtimekit-angular-ui.d.ts",
   "bugs": {
     "url": "https://realtime.cloudflare.com/issues"
   },
-  "homepage": "https://realtime.cloudflare.com"
+  "homepage": "https://realtime.cloudflare.com",
+  "es2020": "dist/fesm2020/cloudflare-realtimekit-angular-ui.mjs",
+  "esm2020": "dist/esm2020/cloudflare-realtimekit-angular-ui.mjs",
+  "fesm2020": "dist/fesm2020/cloudflare-realtimekit-angular-ui.mjs",
+  "fesm2015": "dist/fesm2015/cloudflare-realtimekit-angular-ui.mjs",
+  "exports": {
+    "./package.json": {
+      "default": "./package.json"
+    },
+    ".": {
+      "types": "./dist/cloudflare-realtimekit-angular-ui.d.ts",
+      "esm2020": "./dist/esm2020/cloudflare-realtimekit-angular-ui.mjs",
+      "es2020": "./dist/fesm2020/cloudflare-realtimekit-angular-ui.mjs",
+      "es2015": "./dist/fesm2015/cloudflare-realtimekit-angular-ui.mjs",
+      "node": "./dist/fesm2015/cloudflare-realtimekit-angular-ui.mjs",
+      "default": "./dist/fesm2020/cloudflare-realtimekit-angular-ui.mjs"
+    }
+  }
 }

--- a/packages/angular-library/projects/components/package.json
+++ b/packages/angular-library/projects/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/realtimekit-angular-ui",
-  "version": "1.0.4-staging.4",
+  "version": "1.0.4-staging.5",
   "description": "Pre-built, ready-to-use Angular UI components and utilities for integrating with Cloudflare RealtimeKit",
   "peerDependencies": {
     "@angular/common": ">=12",

--- a/packages/angular-library/projects/components/package.json
+++ b/packages/angular-library/projects/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/realtimekit-angular-ui",
-  "version": "1.0.4-staging.1",
+  "version": "1.0.4-staging.2",
   "description": "Pre-built, ready-to-use Angular UI components and utilities for integrating with Cloudflare RealtimeKit",
   "peerDependencies": {
     "@angular/common": ">=12",

--- a/packages/angular-library/projects/components/package.json
+++ b/packages/angular-library/projects/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/realtimekit-angular-ui",
-  "version": "1.0.4-staging.2",
+  "version": "1.0.4-staging.3",
   "description": "Pre-built, ready-to-use Angular UI components and utilities for integrating with Cloudflare RealtimeKit",
   "peerDependencies": {
     "@angular/common": ">=12",

--- a/packages/angular-library/projects/components/src/lib/stencil-generated/components.ts
+++ b/packages/angular-library/projects/components/src/lib/stencil-generated/components.ts
@@ -3655,14 +3655,14 @@ export declare interface RtkTranscripts extends Components.RtkTranscripts {}
 
 
 @ProxyCmp({
-  inputs: ['config', 'iconPack', 'meeting', 'mode', 'showSetupScreen', 'size', 't']
+  inputs: ['config', 'iconPack', 'meeting', 'mode', 'showSetupScreen', 't']
 })
 @Component({
   selector: 'rtk-ui-provider',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['config', 'iconPack', 'meeting', 'mode', 'showSetupScreen', 'size', 't'],
+  inputs: ['config', 'iconPack', 'meeting', 'mode', 'showSetupScreen', 't'],
 })
 export class RtkUiProvider {
   protected el: HTMLRtkUiProviderElement;

--- a/packages/angular-library/projects/components/src/lib/stencil-generated/components.ts
+++ b/packages/angular-library/projects/components/src/lib/stencil-generated/components.ts
@@ -1954,7 +1954,8 @@ import type { States as IRtkMeetingStates } from '@cloudflare/realtimekit-ui';
 
 export declare interface RtkMeeting extends Components.RtkMeeting {
   /**
-   * States
+   * Emits `rtkStatesUpdate` so that developers can listen to onRtkStatesUpdate and update their own stores
+Do not confuse this with `rtkStateUpdate` that other components emit
    */
   rtkStatesUpdate: EventEmitter<CustomEvent<IRtkMeetingStates>>;
 }
@@ -3654,14 +3655,14 @@ export declare interface RtkTranscripts extends Components.RtkTranscripts {}
 
 
 @ProxyCmp({
-  inputs: ['config', 'iconPack', 'meeting', 'noRenderUntilMeeting', 'showSetupScreen', 'size', 't']
+  inputs: ['config', 'iconPack', 'meeting', 'mode', 'showSetupScreen', 'size', 't']
 })
 @Component({
   selector: 'rtk-ui-provider',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['config', 'iconPack', 'meeting', 'noRenderUntilMeeting', 'showSetupScreen', 'size', 't'],
+  inputs: ['config', 'iconPack', 'meeting', 'mode', 'showSetupScreen', 'size', 't'],
 })
 export class RtkUiProvider {
   protected el: HTMLRtkUiProviderElement;
@@ -3677,7 +3678,8 @@ import type { States as IRtkUiProviderStates } from '@cloudflare/realtimekit-ui'
 
 export declare interface RtkUiProvider extends Components.RtkUiProvider {
   /**
-   * States event
+   * Emits `rtkStatesUpdate` so that developers can listen to onRtkStatesUpdate and update their own stores
+Do not confuse this with `rtkStateUpdate` that other components emit
    */
   rtkStatesUpdate: EventEmitter<CustomEvent<IRtkUiProviderStates>>;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/realtimekit-ui",
-  "version": "1.0.4-staging.3",
+  "version": "1.0.4-staging.4",
   "description": "Pre-built, ready-to-use UI components and utilities for integrating with Cloudflare RealtimeKit",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/realtimekit-ui",
-  "version": "1.0.4-staging.2",
+  "version": "1.0.4-staging.3",
   "description": "Pre-built, ready-to-use UI components and utilities for integrating with Cloudflare RealtimeKit",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/realtimekit-ui",
-  "version": "1.0.4-staging.1",
+  "version": "1.0.4-staging.2",
   "description": "Pre-built, ready-to-use UI components and utilities for integrating with Cloudflare RealtimeKit",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/realtimekit-ui",
-  "version": "1.0.4-staging.4",
+  "version": "1.0.4-staging.5",
   "description": "Pre-built, ready-to-use UI components and utilities for integrating with Cloudflare RealtimeKit",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/realtimekit-ui",
-  "version": "1.0.3",
+  "version": "1.0.4-staging.1",
   "description": "Pre-built, ready-to-use UI components and utilities for integrating with Cloudflare RealtimeKit",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -3884,10 +3884,6 @@ export namespace Components {
          */
         "showSetupScreen": boolean;
         /**
-          * Size
-         */
-        "size": Size1;
-        /**
           * Language utility
          */
         "t": RtkI18n1;
@@ -10813,10 +10809,6 @@ declare namespace LocalJSX {
           * Whether to show setup screen or not
          */
         "showSetupScreen"?: boolean;
-        /**
-          * Size
-         */
-        "size"?: Size1;
         /**
           * Language utility
          */

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -42,6 +42,7 @@ import { RtkSidebarSection } from "./components/rtk-sidebar/rtk-sidebar";
 import { RtkSidebarTab as RtkSidebarTab1, RtkSidebarView as RtkSidebarView1 } from "./components/rtk-sidebar-ui/rtk-sidebar-ui";
 import { Tab } from "./components/rtk-tab-bar/rtk-tab-bar";
 import { TooltipKind, TooltipVariant } from "./components/rtk-tooltip/rtk-tooltip";
+import { MeetingMode as MeetingMode1 } from "./components/rtk-meeting/rtk-meeting";
 import { ViewerCountVariant } from "./components/rtk-viewer-count/rtk-viewer-count";
 import { Peer as Peer1 } from ".";
 export { Meeting, Peer, WaitlistedParticipant } from "./types/rtk-client";
@@ -81,6 +82,7 @@ export { RtkSidebarSection } from "./components/rtk-sidebar/rtk-sidebar";
 export { RtkSidebarTab as RtkSidebarTab1, RtkSidebarView as RtkSidebarView1 } from "./components/rtk-sidebar-ui/rtk-sidebar-ui";
 export { Tab } from "./components/rtk-tab-bar/rtk-tab-bar";
 export { TooltipKind, TooltipVariant } from "./components/rtk-tooltip/rtk-tooltip";
+export { MeetingMode as MeetingMode1 } from "./components/rtk-meeting/rtk-meeting";
 export { ViewerCountVariant } from "./components/rtk-viewer-count/rtk-viewer-count";
 export { Peer as Peer1 } from ".";
 export namespace Components {
@@ -3872,12 +3874,11 @@ export namespace Components {
         /**
           * Meeting
          */
-        "meeting": Meeting;
+        "meeting": Meeting | null;
         /**
-          * Do not render children until meeting is initialized
-          * @default false
+          * Fill type
          */
-        "noRenderUntilMeeting": boolean;
+        "mode": MeetingMode1;
         /**
           * Whether to show setup screen or not
          */
@@ -8721,7 +8722,7 @@ declare namespace LocalJSX {
          */
         "mode"?: MeetingMode;
         /**
-          * States
+          * Emits `rtkStatesUpdate` so that developers can listen to onRtkStatesUpdate and update their own stores Do not confuse this with `rtkStateUpdate` that other components emit
          */
         "onRtkStatesUpdate"?: (event: RtkMeetingCustomEvent<States>) => void;
         /**
@@ -10799,14 +10800,13 @@ declare namespace LocalJSX {
         /**
           * Meeting
          */
-        "meeting"?: Meeting;
+        "meeting"?: Meeting | null;
         /**
-          * Do not render children until meeting is initialized
-          * @default false
+          * Fill type
          */
-        "noRenderUntilMeeting"?: boolean;
+        "mode"?: MeetingMode1;
         /**
-          * States event
+          * Emits `rtkStatesUpdate` so that developers can listen to onRtkStatesUpdate and update their own stores Do not confuse this with `rtkStateUpdate` that other components emit
          */
         "onRtkStatesUpdate"?: (event: RtkUiProviderCustomEvent<States1>) => void;
         /**

--- a/packages/core/src/components/rtk-ai-toggle/rtk-ai-toggle.tsx
+++ b/packages/core/src/components/rtk-ai-toggle/rtk-ai-toggle.tsx
@@ -27,7 +27,7 @@ export class RtkAiToggle {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-ai-toggle/rtk-ai-toggle.tsx
+++ b/packages/core/src/components/rtk-ai-toggle/rtk-ai-toggle.tsx
@@ -60,6 +60,7 @@ export class RtkAiToggle {
   }
 
   render() {
+    if (!this.meeting) return null;
     const text = this.t('ai.meeting_ai');
 
     if (!(this.meeting?.self?.permissions as RTKPermissionsPreset).transcriptionEnabled) {

--- a/packages/core/src/components/rtk-ai/rtk-ai.tsx
+++ b/packages/core/src/components/rtk-ai/rtk-ai.tsx
@@ -4,7 +4,7 @@ import type { Size, States } from '../../types/props';
 import { UIConfig } from '../../types/ui-config';
 import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RtkI18n, useLanguage } from '../../lib/lang';
-import { defaultConfig } from '../../lib/default-ui-config';
+import { createDefaultConfig } from '../../lib/default-ui-config';
 import { SyncWithStore } from '../../utils/sync-with-store';
 import { RTKPermissionsPreset } from '@cloudflare/realtimekit';
 
@@ -29,7 +29,9 @@ export class RtkAi {
   states: States;
 
   /** Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Icon pack */
   @SyncWithStore()
@@ -75,6 +77,7 @@ export class RtkAi {
   };
 
   render() {
+    if (!this.meeting) return null;
     if (
       !(this.meeting?.self?.permissions as RTKPermissionsPreset).transcriptionEnabled ||
       !this.states?.activeAI

--- a/packages/core/src/components/rtk-ai/rtk-ai.tsx
+++ b/packages/core/src/components/rtk-ai/rtk-ai.tsx
@@ -44,7 +44,7 @@ export class RtkAi {
   t: RtkI18n = useLanguage();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** View type */
   @Prop({ reflect: true }) view: AIView = 'sidebar';

--- a/packages/core/src/components/rtk-audio-grid/rtk-audio-grid.tsx
+++ b/packages/core/src/components/rtk-audio-grid/rtk-audio-grid.tsx
@@ -24,7 +24,9 @@ export class RtkAudioGrid {
   meeting: Meeting;
 
   /** Config */
-  @Prop() config: UIConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig;
 
   /** States */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-audio-grid/rtk-audio-grid.tsx
+++ b/packages/core/src/components/rtk-audio-grid/rtk-audio-grid.tsx
@@ -39,7 +39,7 @@ export class RtkAudioGrid {
   iconPack: IconPack = defaultIconPack;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Language */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-audio-tile/rtk-audio-tile.tsx
+++ b/packages/core/src/components/rtk-audio-tile/rtk-audio-tile.tsx
@@ -26,7 +26,7 @@ export class RtkAudioTile {
   config: UIConfig;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** States */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-audio-tile/rtk-audio-tile.tsx
+++ b/packages/core/src/components/rtk-audio-tile/rtk-audio-tile.tsx
@@ -21,7 +21,9 @@ export class RtkAudioTile {
   meeting: Meeting;
 
   /** Config */
-  @Prop() config: UIConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig;
 
   /** Size */
   @SyncWithStore() @Prop({ reflect: true }) size: Size;
@@ -116,6 +118,7 @@ export class RtkAudioTile {
   }
 
   render() {
+    if (!this.meeting) return null;
     const defaults = {
       meeting: this.meeting,
       size: this.size,

--- a/packages/core/src/components/rtk-audio-visualizer/rtk-audio-visualizer.tsx
+++ b/packages/core/src/components/rtk-audio-visualizer/rtk-audio-visualizer.tsx
@@ -36,7 +36,7 @@ export class RtkAudioVisualizer {
   @Prop() participant: Peer;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-avatar/rtk-avatar.tsx
+++ b/packages/core/src/components/rtk-avatar/rtk-avatar.tsx
@@ -24,7 +24,7 @@ export class RtkAvatar {
   @Prop({ reflect: true }) variant: AvatarVariant = 'circular';
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-breakout-room-manager/rtk-breakout-room-manager.tsx
+++ b/packages/core/src/components/rtk-breakout-room-manager/rtk-breakout-room-manager.tsx
@@ -264,6 +264,7 @@ export class RtkBreakoutRoomManager {
   }
 
   render() {
+    if (!this.meeting) return null;
     return (
       <Host>
         <div

--- a/packages/core/src/components/rtk-breakout-room-participants/rtk-breakout-room-participants.tsx
+++ b/packages/core/src/components/rtk-breakout-room-participants/rtk-breakout-room-participants.tsx
@@ -63,7 +63,7 @@ export class RtkBreakoutRoomParticipants {
   }
 
   disconnectedCallback() {
-    if (this.meeting == null) return;
+    if (!this.meeting) return;
   }
 
   private updateSelectedParticipants(participant: ConnectedPeer, selected: boolean) {
@@ -79,7 +79,7 @@ export class RtkBreakoutRoomParticipants {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting == null) return;
+    if (!meeting) return;
     this.getParticipants(this.search);
   }
 

--- a/packages/core/src/components/rtk-breakout-room-toggle/rtk-breakout-rooms-toggle.tsx
+++ b/packages/core/src/components/rtk-breakout-room-toggle/rtk-breakout-rooms-toggle.tsx
@@ -78,6 +78,7 @@ export class RtkBreakoutRoomsToggle {
   };
 
   render() {
+    if (!this.meeting) return null;
     if (!this.canToggle) return;
     return (
       <Host title={this.t('breakout_rooms')}>

--- a/packages/core/src/components/rtk-breakout-room-toggle/rtk-breakout-rooms-toggle.tsx
+++ b/packages/core/src/components/rtk-breakout-room-toggle/rtk-breakout-rooms-toggle.tsx
@@ -32,7 +32,7 @@ export class RtkBreakoutRoomsToggle {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-button/rtk-button.tsx
+++ b/packages/core/src/components/rtk-button/rtk-button.tsx
@@ -1,6 +1,5 @@
 import { Size } from '../../types/props';
 import { Component, Host, h, Prop } from '@stencil/core';
-import { SyncWithStore } from '../../utils/sync-with-store';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost';
 
@@ -20,7 +19,7 @@ export type ButtonKind = 'button' | 'icon' | 'wide';
 })
 export class RtkButton {
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Button variant */
   @Prop({ reflect: true }) variant: ButtonVariant = 'primary';

--- a/packages/core/src/components/rtk-camera-selector/rtk-camera-selector.tsx
+++ b/packages/core/src/components/rtk-camera-selector/rtk-camera-selector.tsx
@@ -52,7 +52,7 @@ export class RtkCameraSelector {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting == null) return;
+    if (!meeting) return;
 
     meeting.self?.addListener('deviceListUpdate', this.deviceListUpdateListener);
     meeting.self?.addListener('deviceUpdate', this.deviceUpdateListener);
@@ -116,7 +116,7 @@ export class RtkCameraSelector {
   }
 
   render() {
-    if (this.meeting == null) return null;
+    if (!this.meeting) return null;
 
     let unnamedVideoCount = 0;
 

--- a/packages/core/src/components/rtk-camera-selector/rtk-camera-selector.tsx
+++ b/packages/core/src/components/rtk-camera-selector/rtk-camera-selector.tsx
@@ -29,7 +29,7 @@ export class RtkCameraSelector {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-camera-toggle/rtk-camera-toggle.tsx
+++ b/packages/core/src/components/rtk-camera-toggle/rtk-camera-toggle.tsx
@@ -48,7 +48,7 @@ export class RtkCameraToggle {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-camera-toggle/rtk-camera-toggle.tsx
+++ b/packages/core/src/components/rtk-camera-toggle/rtk-camera-toggle.tsx
@@ -186,6 +186,7 @@ export class RtkCameraToggle {
   }
 
   render() {
+    if (!this.meeting) return null;
     if (
       !this.canProduceVideo ||
       this.meeting?.meta.viewType === 'AUDIO_ROOM' ||

--- a/packages/core/src/components/rtk-caption-toggle/rtk-caption-toggle.tsx
+++ b/packages/core/src/components/rtk-caption-toggle/rtk-caption-toggle.tsx
@@ -1,5 +1,12 @@
 import { Component, Host, h, Event, EventEmitter, Prop, Watch, State } from '@stencil/core';
-import { defaultConfig, defaultIconPack, IconPack, Size, States, UIConfig } from '../../exports';
+import {
+  createDefaultConfig,
+  defaultIconPack,
+  IconPack,
+  Size,
+  States,
+  UIConfig,
+} from '../../exports';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { Meeting } from '../../types/rtk-client';
 import { ControlBarVariant } from '../rtk-controlbar-button/rtk-controlbar-button';
@@ -26,7 +33,9 @@ export class RtkCaptionToggle {
   states: States;
 
   /** Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Icon pack */
   @SyncWithStore()
@@ -75,6 +84,7 @@ export class RtkCaptionToggle {
   }
 
   render() {
+    if (!this.meeting) return null;
     if (!this.captionEnabled) return null;
     const captionsEnabled = this.states.activeCaptions;
     return (

--- a/packages/core/src/components/rtk-caption-toggle/rtk-caption-toggle.tsx
+++ b/packages/core/src/components/rtk-caption-toggle/rtk-caption-toggle.tsx
@@ -43,7 +43,7 @@ export class RtkCaptionToggle {
   iconPack: IconPack = defaultIconPack;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Language */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-chat-composer-ui/rtk-chat-composer-ui.tsx
+++ b/packages/core/src/components/rtk-chat-composer-ui/rtk-chat-composer-ui.tsx
@@ -56,7 +56,7 @@ export class RtkChatComposerUi {
   @Prop() canSendFiles = false;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-chat-message/rtk-chat-message.tsx
+++ b/packages/core/src/components/rtk-chat-message/rtk-chat-message.tsx
@@ -34,7 +34,7 @@ export class RtkChatMessage {
   @Prop() isUnread: boolean;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-chat-messages-ui-paginated/rtk-chat-messages-ui-paginated.tsx
+++ b/packages/core/src/components/rtk-chat-messages-ui-paginated/rtk-chat-messages-ui-paginated.tsx
@@ -42,7 +42,7 @@ export class RtkChatMessagesUiPaginated {
   @Prop() selectedChannelId?: string;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-chat-messages-ui/rtk-chat-messages-ui.tsx
+++ b/packages/core/src/components/rtk-chat-messages-ui/rtk-chat-messages-ui.tsx
@@ -49,7 +49,7 @@ export class RtkChatMessagesUi {
   @Prop() canPinMessages: boolean = false;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
+++ b/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
@@ -41,7 +41,7 @@ export class RtkChatToggle {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
+++ b/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
@@ -75,7 +75,7 @@ export class RtkChatToggle {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting == null) return;
+    if (!meeting) return;
     if (usePaginatedChat(meeting)) {
       meeting.chat?.getMessages(new Date().getTime(), 1, true).then((res) => {
         if (res?.messages?.length) this.hasNewMessages = true;
@@ -140,6 +140,7 @@ export class RtkChatToggle {
   private buttonEl: HTMLRtkControlbarButtonElement;
 
   render() {
+    if (!this.meeting) return null;
     if (!this.canViewChat) return <Host data-hidden />;
     return (
       <Host title={this.t('chat')}>

--- a/packages/core/src/components/rtk-chat/rtk-chat.tsx
+++ b/packages/core/src/components/rtk-chat/rtk-chat.tsx
@@ -73,7 +73,7 @@ export class RtkChat {
   config: UIConfig = createDefaultConfig();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-chat/rtk-chat.tsx
+++ b/packages/core/src/components/rtk-chat/rtk-chat.tsx
@@ -29,7 +29,7 @@ import {
 import { chatUnreadTimestamps } from '../../utils/user-prefs';
 import { FlagsmithFeatureFlags, usePaginatedChat } from '../../utils/flags';
 import { RtkChannelHeaderCustomEvent } from '../../components';
-import { States, UIConfig, defaultConfig } from '../../exports';
+import { States, UIConfig, createDefaultConfig } from '../../exports';
 import { ChannelItem } from '../rtk-channel-selector-view/rtk-channel-selector-view';
 import { SyncWithStore } from '../../utils/sync-with-store';
 import { NewMessageEvent } from '../rtk-chat-composer-view/rtk-chat-composer-view';
@@ -68,7 +68,9 @@ export class RtkChat {
   meeting: Meeting;
 
   /** Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Size */
   @SyncWithStore() @Prop({ reflect: true }) size: Size;
@@ -818,7 +820,9 @@ export class RtkChat {
   };
 
   render() {
-    if (!this.meeting) return null;
+    if (!this.meeting) {
+      return null;
+    }
 
     const uiProps = { iconPack: this.iconPack, t: this.t, size: this.size };
 

--- a/packages/core/src/components/rtk-controlbar-button/rtk-controlbar-button.tsx
+++ b/packages/core/src/components/rtk-controlbar-button/rtk-controlbar-button.tsx
@@ -21,7 +21,7 @@ export class RtkControlbarButton {
   @Prop() showWarning: boolean = false;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Label of button */
   @Prop() label: string;

--- a/packages/core/src/components/rtk-controlbar/rtk-controlbar.tsx
+++ b/packages/core/src/components/rtk-controlbar/rtk-controlbar.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop } from '@stencil/core';
-import { defaultConfig, defaultIconPack, IconPack, UIConfig } from '../../exports';
+import { createDefaultConfig, defaultIconPack, IconPack, UIConfig } from '../../exports';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { Render } from '../../lib/render';
 import { Meeting } from '../../types/rtk-client';
@@ -29,7 +29,9 @@ export class RtkControlbar {
   meeting: Meeting;
 
   /** Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** States */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-controlbar/rtk-controlbar.tsx
+++ b/packages/core/src/components/rtk-controlbar/rtk-controlbar.tsx
@@ -49,7 +49,7 @@ export class RtkControlbar {
   t: RtkI18n = useLanguage();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   render() {
     const defaults = {

--- a/packages/core/src/components/rtk-counter/rtk-counter.tsx
+++ b/packages/core/src/components/rtk-counter/rtk-counter.tsx
@@ -16,7 +16,7 @@ export class RtkCounter {
   @State() input: string = '1';
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Initial value */
   @Prop() value: number;

--- a/packages/core/src/components/rtk-debugger-audio/rtk-debugger-audio.tsx
+++ b/packages/core/src/components/rtk-debugger-audio/rtk-debugger-audio.tsx
@@ -31,7 +31,7 @@ export class RtkDebuggerAudio {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-debugger-screenshare/rtk-debugger-screenshare.tsx
+++ b/packages/core/src/components/rtk-debugger-screenshare/rtk-debugger-screenshare.tsx
@@ -37,7 +37,7 @@ export class RtkDebuggerScreenShare {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-debugger-system/rtk-debugger-system.tsx
+++ b/packages/core/src/components/rtk-debugger-system/rtk-debugger-system.tsx
@@ -44,7 +44,7 @@ export class RtkDebuggerSystem {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-debugger-toggle/rtk-debugger-toggle.tsx
+++ b/packages/core/src/components/rtk-debugger-toggle/rtk-debugger-toggle.tsx
@@ -39,7 +39,7 @@ export class RtkDebuggerToggle {
   @Event({ eventName: 'rtkStateUpdate' }) stateUpdate: EventEmitter<States>;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   private toggleDebugger() {
     this.stateUpdate.emit({

--- a/packages/core/src/components/rtk-debugger-video/rtk-debugger-video.tsx
+++ b/packages/core/src/components/rtk-debugger-video/rtk-debugger-video.tsx
@@ -31,7 +31,7 @@ export class RtkDebuggerVideo {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-debugger/rtk-debugger.tsx
+++ b/packages/core/src/components/rtk-debugger/rtk-debugger.tsx
@@ -32,7 +32,7 @@ export class RtkDebugger {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-debugger/rtk-debugger.tsx
+++ b/packages/core/src/components/rtk-debugger/rtk-debugger.tsx
@@ -93,7 +93,7 @@ export class RtkDebugger {
   }
 
   render() {
-    if (this.meeting == null) return null;
+    if (!this.meeting) return null;
 
     const defaults = {
       meeting: this.meeting,

--- a/packages/core/src/components/rtk-dialog-manager/rtk-dialog-manager.tsx
+++ b/packages/core/src/components/rtk-dialog-manager/rtk-dialog-manager.tsx
@@ -1,5 +1,5 @@
 import { Component, Watch, Host, h, Prop, Event, EventEmitter } from '@stencil/core';
-import { defaultConfig } from '../../lib/default-ui-config';
+import { createDefaultConfig } from '../../lib/default-ui-config';
 import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { Meeting } from '../../types/rtk-client';
@@ -31,7 +31,9 @@ export class RtkDialogManager {
   meeting: Meeting;
 
   /** UI Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** States object */
   @SyncWithStore()
@@ -92,6 +94,10 @@ export class RtkDialogManager {
   };
 
   render() {
+    if (!this.meeting) {
+      return;
+    }
+
     const defaults = {
       meeting: this.meeting,
       states: this.states,

--- a/packages/core/src/components/rtk-dialog-manager/rtk-dialog-manager.tsx
+++ b/packages/core/src/components/rtk-dialog-manager/rtk-dialog-manager.tsx
@@ -41,7 +41,7 @@ export class RtkDialogManager {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-dialog/rtk-dialog.tsx
+++ b/packages/core/src/components/rtk-dialog/rtk-dialog.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop, Event, EventEmitter } from '@stencil/core';
-import { defaultConfig } from '../../lib/default-ui-config';
+import { createDefaultConfig } from '../../lib/default-ui-config';
 import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { Meeting } from '../../types/rtk-client';
@@ -28,7 +28,9 @@ export class RtkDialog {
   meeting: Meeting;
 
   /** UI Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** States object */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-dialog/rtk-dialog.tsx
+++ b/packages/core/src/components/rtk-dialog/rtk-dialog.tsx
@@ -38,7 +38,7 @@ export class RtkDialog {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-ended-screen/rtk-ended-screen.tsx
+++ b/packages/core/src/components/rtk-ended-screen/rtk-ended-screen.tsx
@@ -3,7 +3,7 @@ import { RtkI18n, defaultLanguage, useLanguage } from '../../lib/lang';
 import { Size, States } from '../../types/props';
 import { UIConfig } from '../../types/ui-config';
 import { defaultIconPack, IconPack } from '../../lib/icons';
-import { defaultConfig } from '../../exports';
+import { createDefaultConfig } from '../../exports';
 import { SyncWithStore } from '../../utils/sync-with-store';
 import { Meeting } from '../../types/rtk-client';
 
@@ -17,7 +17,9 @@ import { Meeting } from '../../types/rtk-client';
 })
 export class RtkEndedScreen {
   /** Config object */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Size */
   @SyncWithStore() @Prop({ reflect: true }) size: Size;
@@ -109,6 +111,7 @@ export class RtkEndedScreen {
   }
 
   render() {
+    if (!this.meeting) return null;
     const states = this.states;
     if (states.roomLeftState === 'connected-meeting') {
       return this.renderBreakoutRoomScreen();

--- a/packages/core/src/components/rtk-ended-screen/rtk-ended-screen.tsx
+++ b/packages/core/src/components/rtk-ended-screen/rtk-ended-screen.tsx
@@ -22,7 +22,7 @@ export class RtkEndedScreen {
   config: UIConfig = createDefaultConfig();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon */
   @State() icon: IconPack = defaultIconPack;

--- a/packages/core/src/components/rtk-fullscreen-toggle/rtk-fullscreen-toggle.tsx
+++ b/packages/core/src/components/rtk-fullscreen-toggle/rtk-fullscreen-toggle.tsx
@@ -33,7 +33,7 @@ export class RtkFullscreenToggle {
   @Prop({ reflect: true }) variant: ControlBarVariant = 'button';
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-grid-pagination/rtk-grid-pagination.tsx
+++ b/packages/core/src/components/rtk-grid-pagination/rtk-grid-pagination.tsx
@@ -59,7 +59,7 @@ export class RtkGridPagination {
   }
 
   disconnectedCallback() {
-    if (this.meeting == null) return;
+    if (!this.meeting) return;
 
     const { participants, stage } = this.meeting;
 
@@ -134,7 +134,7 @@ export class RtkGridPagination {
   }, MASS_ACTIONS_DEBOUNCE_TIMER);
 
   private prevPage = () => {
-    if (this.meeting == null) return;
+    if (!this.meeting) return;
 
     const { participants } = this.meeting;
 
@@ -146,7 +146,7 @@ export class RtkGridPagination {
   };
 
   private nextPage = () => {
-    if (this.meeting == null) return;
+    if (!this.meeting) return;
 
     const { participants } = this.meeting;
 
@@ -158,6 +158,7 @@ export class RtkGridPagination {
   };
 
   render() {
+    if (!this.meeting) return null;
     const { meta } = this.meeting;
     const isAudioRoom = meta?.viewType === 'AUDIO_ROOM';
 

--- a/packages/core/src/components/rtk-grid-pagination/rtk-grid-pagination.tsx
+++ b/packages/core/src/components/rtk-grid-pagination/rtk-grid-pagination.tsx
@@ -32,7 +32,7 @@ export class RtkGridPagination {
   states: States;
 
   /** Size Prop */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Variant */
   @Prop({ reflect: true }) variant: GridPaginationVariants = 'rounded';

--- a/packages/core/src/components/rtk-grid/rtk-grid.tsx
+++ b/packages/core/src/components/rtk-grid/rtk-grid.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop, State, Watch, Event, EventEmitter } from '@stencil/core';
-import { defaultConfig } from '../../lib/default-ui-config';
+import { createDefaultConfig } from '../../lib/default-ui-config';
 import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { Meeting, Peer } from '../../types/rtk-client';
@@ -11,7 +11,6 @@ import { RTKPlugin, leaveRoomState } from '@cloudflare/realtimekit';
 import { isLiveStreamViewer } from '../../utils/livestream';
 import { SyncWithStore } from '../../utils/sync-with-store';
 import { defaultGridSize } from '../../lib/grid';
-import { uiState } from '../../utils/sync-with-store/ui-store';
 
 export type GridLayout = 'row' | 'column';
 
@@ -80,7 +79,9 @@ export class RtkGrid {
   states: States;
 
   /** Config object */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Icon pack */
   @SyncWithStore()
@@ -110,7 +111,7 @@ export class RtkGrid {
   }
 
   private disconnectMeeting(meeting: Meeting) {
-    if (meeting == null) return;
+    if (!meeting) return;
     this.participants = [];
     this.plugins = [];
 
@@ -214,28 +215,28 @@ export class RtkGrid {
   @Watch('screenShareParticipants')
   screenShareParticipantsChanged(participants: Peer[]) {
     const activeScreenShare = participants.length > 0;
-    if (!!uiState.states.activeScreenShare === activeScreenShare) return;
+    if (!!this.states.activeScreenShare === activeScreenShare) return;
 
     this.stateUpdate.emit({ activeScreenShare });
-    uiState.states.activeScreenShare = activeScreenShare;
+    this.states.activeScreenShare = activeScreenShare;
   }
 
   @Watch('plugins')
   pluginsChanged(plugins: RTKPlugin[]) {
     const activePlugin = plugins.length > 0;
-    if (!!uiState.states.activePlugin === activePlugin) return;
+    if (!!this.states.activePlugin === activePlugin) return;
 
     this.stateUpdate.emit({ activePlugin });
-    uiState.states.activePlugin = activePlugin;
+    this.states.activePlugin = activePlugin;
   }
 
   @Watch('pinnedParticipants')
   pinnedParticipantsChanged(participants: Peer[]) {
     const activeSpotlight = participants.length > 0;
-    if (!!uiState.states.activeSpotlight === activeSpotlight) return;
+    if (!!this.states.activeSpotlight === activeSpotlight) return;
 
     this.stateUpdate.emit({ activeSpotlight });
-    uiState.states.activeSpotlight = activeSpotlight;
+    this.states.activeSpotlight = activeSpotlight;
   }
 
   private invalidRoomStates = ['init', 'waitlisted', 'ended', 'kicked', 'rejected'];
@@ -302,7 +303,7 @@ export class RtkGrid {
   };
 
   private onViewModeChanged = () => {
-    if (this.meeting == null) return;
+    if (!this.meeting) return;
     this.updateActiveParticipants();
   };
 

--- a/packages/core/src/components/rtk-grid/rtk-grid.tsx
+++ b/packages/core/src/components/rtk-grid/rtk-grid.tsx
@@ -71,7 +71,7 @@ export class RtkGrid {
   @Prop({ reflect: true }) gap: number = 8;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** States */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-header/rtk-header.tsx
+++ b/packages/core/src/components/rtk-header/rtk-header.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop } from '@stencil/core';
-import { defaultConfig, defaultIconPack, IconPack, UIConfig } from '../../exports';
+import { createDefaultConfig, defaultIconPack, IconPack, UIConfig } from '../../exports';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { Render } from '../../lib/render';
 import { Meeting } from '../../types/rtk-client';
@@ -29,7 +29,9 @@ export class RtkHeader {
   meeting: Meeting;
 
   /** Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** States */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-header/rtk-header.tsx
+++ b/packages/core/src/components/rtk-header/rtk-header.tsx
@@ -49,7 +49,7 @@ export class RtkHeader {
   t: RtkI18n = useLanguage();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   render() {
     const defaults = {

--- a/packages/core/src/components/rtk-icon/rtk-icon.tsx
+++ b/packages/core/src/components/rtk-icon/rtk-icon.tsx
@@ -1,6 +1,5 @@
 import { Component, Host, h, Prop } from '@stencil/core';
 import { Size } from '../../exports';
-import { SyncWithStore } from '../../utils/sync-with-store';
 
 const parseIcon = (icon: string) => {
   try {
@@ -28,7 +27,7 @@ export class RtkIcon {
   @Prop({ reflect: true }) variant: IconVariant = 'primary';
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size = 'lg';
+  @Prop({ reflect: true }) size: Size = 'lg';
 
   render() {
     return (

--- a/packages/core/src/components/rtk-idle-screen/rtk-idle-screen.tsx
+++ b/packages/core/src/components/rtk-idle-screen/rtk-idle-screen.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop } from '@stencil/core';
-import { defaultConfig } from '../../exports';
+import { createDefaultConfig } from '../../exports';
 import { IconPack, defaultIconPack } from '../../lib/icons';
 import { useLanguage, RtkI18n } from '../../lib/lang';
 import { UIConfig } from '../../types/ui-config';
@@ -22,7 +22,9 @@ export class RtkIdleScreen {
   meeting: Meeting;
 
   /** Config object */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-image-viewer/rtk-image-viewer.tsx
+++ b/packages/core/src/components/rtk-image-viewer/rtk-image-viewer.tsx
@@ -20,7 +20,7 @@ export class RtkImageViewer {
   @Prop() image!: ImageMessage;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Language */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-join-stage/rtk-join-stage.tsx
+++ b/packages/core/src/components/rtk-join-stage/rtk-join-stage.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop, Event, EventEmitter, State } from '@stencil/core';
-import { defaultConfig } from '../../lib/default-ui-config';
+import { createDefaultConfig } from '../../lib/default-ui-config';
 import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { Render } from '../../lib/render';
@@ -29,7 +29,9 @@ export class RtkJoinStage {
   meeting: Meeting;
 
   /** UI Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** States object */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-join-stage/rtk-join-stage.tsx
+++ b/packages/core/src/components/rtk-join-stage/rtk-join-stage.tsx
@@ -39,7 +39,7 @@ export class RtkJoinStage {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-leave-button/rtk-leave-button.tsx
+++ b/packages/core/src/components/rtk-leave-button/rtk-leave-button.tsx
@@ -18,7 +18,7 @@ export class RtkLeaveButton {
   @Prop({ reflect: true }) variant: ControlBarVariant = 'button';
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-livestream-indicator/rtk-livestream-indicator.tsx
+++ b/packages/core/src/components/rtk-livestream-indicator/rtk-livestream-indicator.tsx
@@ -40,7 +40,7 @@ export class RtkLivestreamIndicator {
   }
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting == null) return;
+    if (!meeting) return;
     this.setIsLivestreaming(this.meeting.livestream?.state);
     this.meeting.livestream?.on('livestreamUpdate', this.setIsLivestreaming);
   }

--- a/packages/core/src/components/rtk-livestream-indicator/rtk-livestream-indicator.tsx
+++ b/packages/core/src/components/rtk-livestream-indicator/rtk-livestream-indicator.tsx
@@ -18,7 +18,7 @@ export class RtkLivestreamIndicator {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Language */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-livestream-player/rtk-livestream-player.tsx
+++ b/packages/core/src/components/rtk-livestream-player/rtk-livestream-player.tsx
@@ -370,7 +370,7 @@ export class RtkLivestreamPlayer {
 
   @Watch('meeting')
   meetingChanged(meeting) {
-    if (meeting == null) return;
+    if (!meeting) return;
     this.playbackUrl = this.meeting.livestream.playbackUrl;
     this.livestreamState = this.meeting.livestream.state;
     this.meeting.livestream.on('livestreamUpdate', this.livestreamUpdateListener);

--- a/packages/core/src/components/rtk-livestream-player/rtk-livestream-player.tsx
+++ b/packages/core/src/components/rtk-livestream-player/rtk-livestream-player.tsx
@@ -45,7 +45,7 @@ export class RtkLivestreamPlayer {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Language */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-livestream-toggle/rtk-livestream-toggle.tsx
+++ b/packages/core/src/components/rtk-livestream-toggle/rtk-livestream-toggle.tsx
@@ -23,7 +23,7 @@ export class RtkLivestreamToggle {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-livestream-toggle/rtk-livestream-toggle.tsx
+++ b/packages/core/src/components/rtk-livestream-toggle/rtk-livestream-toggle.tsx
@@ -59,7 +59,7 @@ export class RtkLivestreamToggle {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting == null) return;
+    if (!meeting) return;
     this.livestreamState = this.meeting.livestream?.state;
     this.meeting.livestream?.on('livestreamUpdate', this.livestreamStateListener);
   }
@@ -131,13 +131,12 @@ export class RtkLivestreamToggle {
 
   private isLoading = () => {
     return (
-      this.meeting == null ||
-      this.livestreamState === 'STARTING' ||
-      this.livestreamState === 'STOPPING'
+      !this.meeting || this.livestreamState === 'STARTING' || this.livestreamState === 'STOPPING'
     );
   };
 
   render() {
+    if (!this.meeting) return null;
     if (!isLiveStreamHost(this.meeting)) return <Host data-hidden />;
     return (
       <Host>

--- a/packages/core/src/components/rtk-logo/rtk-logo.tsx
+++ b/packages/core/src/components/rtk-logo/rtk-logo.tsx
@@ -3,7 +3,7 @@ import { Component, Host, h, Prop, Watch } from '@stencil/core';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { Meeting } from '../../types/rtk-client';
 import { SyncWithStore } from '../../utils/sync-with-store';
-import { defaultConfig } from '../../exports';
+import { createDefaultConfig } from '../../exports';
 
 /**
  * A component which loads the logo from your config, or via the `logo-url` attribute.
@@ -18,7 +18,9 @@ export class RtkLogo {
   @Prop({ mutable: true }) logoUrl: string;
 
   /** Config object */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Meeting object */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-meeting/rtk-meeting.tsx
+++ b/packages/core/src/components/rtk-meeting/rtk-meeting.tsx
@@ -150,7 +150,6 @@ export class RtkMeeting {
     this.iconPackChanged(this.iconPack);
     this.tChanged(this.t);
     this.configChanged(this.config);
-    this.sizeChanged(this.size);
 
     this.resizeObserver = new ResizeObserver(() => this.handleResize());
     this.resizeObserver.observe(this.host);
@@ -251,7 +250,6 @@ export class RtkMeeting {
         config: this.config,
         iconPack: this.iconPack,
         t: this.t,
-        size: this.size,
         providerId: this.providerId,
       }) as RtkUiStoreExtended;
 
@@ -340,13 +338,6 @@ export class RtkMeeting {
   tChanged(newT: RtkI18n) {
     if (this.peerStore) {
       this.peerStore.state.t = newT;
-    }
-  }
-
-  @Watch('size')
-  sizeChanged(newSize: Size) {
-    if (this.peerStore) {
-      this.peerStore.state.size = newSize;
     }
   }
 

--- a/packages/core/src/components/rtk-meeting/rtk-meeting.tsx
+++ b/packages/core/src/components/rtk-meeting/rtk-meeting.tsx
@@ -147,6 +147,10 @@ export class RtkMeeting {
     this.setupStateUpdateListener();
 
     this.meetingChanged(this.meeting);
+    this.iconPackChanged(this.iconPack);
+    this.tChanged(this.t);
+    this.configChanged(this.config);
+    this.sizeChanged(this.size);
 
     this.resizeObserver = new ResizeObserver(() => this.handleResize());
     this.resizeObserver.observe(this.host);
@@ -325,10 +329,39 @@ export class RtkMeeting {
     });
   };
 
+  @Watch('iconPack')
+  iconPackChanged(newIconPack: IconPack) {
+    if (this.peerStore) {
+      this.peerStore.state.iconPack = newIconPack;
+    }
+  }
+
+  @Watch('t')
+  tChanged(newT: RtkI18n) {
+    if (this.peerStore) {
+      this.peerStore.state.t = newT;
+    }
+  }
+
   @Watch('size')
-  onSizeChange(newSize: Size) {
+  sizeChanged(newSize: Size) {
     if (this.peerStore) {
       this.peerStore.state.size = newSize;
+    }
+  }
+
+  @Watch('config')
+  configChanged(config: UIConfig) {
+    if (this.peerStore) {
+      this.peerStore.state.config = config;
+    }
+
+    if (
+      config?.designTokens &&
+      typeof document !== 'undefined' &&
+      (this.peerStore || legacyGlobalUIStore).state.states.activeDebugger !== true
+    ) {
+      provideRtkDesignSystem(document.documentElement, config.designTokens);
     }
   }
 

--- a/packages/core/src/components/rtk-menu-item/rtk-menu-item.tsx
+++ b/packages/core/src/components/rtk-menu-item/rtk-menu-item.tsx
@@ -18,7 +18,7 @@ import { useLanguage, RtkI18n } from '../../lib/lang';
 })
 export class RtkMenuItem {
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-menu/rtk-menu.tsx
+++ b/packages/core/src/components/rtk-menu/rtk-menu.tsx
@@ -24,7 +24,7 @@ export class RtkMenu {
   private clickedThis: boolean = false;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Placement of menu */
   @Prop() placement: Placement = 'bottom-end';

--- a/packages/core/src/components/rtk-mic-toggle/rtk-mic-toggle.tsx
+++ b/packages/core/src/components/rtk-mic-toggle/rtk-mic-toggle.tsx
@@ -187,6 +187,7 @@ export class RtkMicToggle {
   }
 
   render() {
+    if (!this.meeting) return null;
     if (
       !this.canProduceAudio ||
       ['OFF_STAGE', 'REQUESTED_TO_JOIN_STAGE'].includes(this.stageStatus)

--- a/packages/core/src/components/rtk-mic-toggle/rtk-mic-toggle.tsx
+++ b/packages/core/src/components/rtk-mic-toggle/rtk-mic-toggle.tsx
@@ -48,7 +48,7 @@ export class RtkMicToggle {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-microphone-selector/rtk-microphone-selector.tsx
+++ b/packages/core/src/components/rtk-microphone-selector/rtk-microphone-selector.tsx
@@ -88,7 +88,7 @@ export class RtkMicrophoneSelector {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting == null) return;
+    if (!meeting) return;
 
     writeTask(async () => {
       const { self, stage } = meeting;
@@ -97,7 +97,7 @@ export class RtkMicrophoneSelector {
       this.currentDevices = {
         audio: currentAudioDevice,
       };
-      this.canProduceAudio = this.meeting.self.permissions.canProduceAudio === 'ALLOWED';
+      this.canProduceAudio = meeting.self.permissions.canProduceAudio === 'ALLOWED';
 
       stage?.addListener('stageStatusUpdate', this.stageStateListener);
       self.addListener('deviceListUpdate', this.deviceListUpdateListener);
@@ -129,7 +129,7 @@ export class RtkMicrophoneSelector {
   }
 
   render() {
-    if (this.meeting == null) return null;
+    if (!this.meeting) return null;
 
     let unnamedMicCount = 0;
 

--- a/packages/core/src/components/rtk-microphone-selector/rtk-microphone-selector.tsx
+++ b/packages/core/src/components/rtk-microphone-selector/rtk-microphone-selector.tsx
@@ -30,7 +30,7 @@ export class RtkMicrophoneSelector {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-mixed-grid/rtk-mixed-grid.tsx
+++ b/packages/core/src/components/rtk-mixed-grid/rtk-mixed-grid.tsx
@@ -50,7 +50,7 @@ export class RtkMixedGrid {
   @Prop() gap: number = 8;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Meeting object */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-mixed-grid/rtk-mixed-grid.tsx
+++ b/packages/core/src/components/rtk-mixed-grid/rtk-mixed-grid.tsx
@@ -1,7 +1,7 @@
 import { RTKPlugin } from '@cloudflare/realtimekit';
 import type { ActiveTab, ActiveTabType } from '@cloudflare/realtimekit';
 import { Component, Host, h, Prop, Element, State, Watch } from '@stencil/core';
-import { defaultConfig } from '../../lib/default-ui-config';
+import { createDefaultConfig } from '../../lib/default-ui-config';
 import { defaultGridSize } from '../../lib/grid';
 import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RtkI18n, useLanguage } from '../../lib/lang';
@@ -63,7 +63,9 @@ export class RtkMixedGrid {
   states: States;
 
   /** UI Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Icon Pack */
   @SyncWithStore()
@@ -198,6 +200,7 @@ export class RtkMixedGrid {
   }
 
   render() {
+    if (!this.meeting) return null;
     const defaults = {
       meeting: this.meeting,
       config: this.config,

--- a/packages/core/src/components/rtk-more-toggle/rtk-more-toggle.tsx
+++ b/packages/core/src/components/rtk-more-toggle/rtk-more-toggle.tsx
@@ -26,7 +26,7 @@ export class RtkMoreToggle {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-mute-all-button/rtk-mute-all-button.tsx
+++ b/packages/core/src/components/rtk-mute-all-button/rtk-mute-all-button.tsx
@@ -20,7 +20,7 @@ export class RtkMuteAllButton {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-mute-all-button/rtk-mute-all-button.tsx
+++ b/packages/core/src/components/rtk-mute-all-button/rtk-mute-all-button.tsx
@@ -64,6 +64,7 @@ export class RtkMuteAllButton {
   };
 
   render() {
+    if (!this.meeting) return null;
     if (!this.canDisable) {
       return null;
     }

--- a/packages/core/src/components/rtk-name-tag/rtk-name-tag.tsx
+++ b/packages/core/src/components/rtk-name-tag/rtk-name-tag.tsx
@@ -26,7 +26,7 @@ export class RtkNameTag {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Whether it is used in a screen share view */
   @Prop() isScreenShare: boolean = false;

--- a/packages/core/src/components/rtk-notification/rtk-notification.tsx
+++ b/packages/core/src/components/rtk-notification/rtk-notification.tsx
@@ -24,7 +24,7 @@ export class RtkNotification {
   @Prop() paused: boolean;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-notifications/rtk-notifications.tsx
+++ b/packages/core/src/components/rtk-notifications/rtk-notifications.tsx
@@ -19,7 +19,7 @@ import type {
   ChatUpdateParams,
   SocketConnectionState,
 } from '@cloudflare/realtimekit';
-import { defaultConfig } from '../../exports';
+import { createDefaultConfig } from '../../exports';
 import { parseMessageForTarget } from '../../utils/chat';
 import { SyncWithStore } from '../../utils/sync-with-store';
 import { showLivestream } from '../../utils/livestream';
@@ -94,7 +94,9 @@ export class RtkNotifications {
   states: States;
 
   /** Config object */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Language */
   @SyncWithStore()
@@ -148,7 +150,7 @@ export class RtkNotifications {
       document?.removeEventListener('rtkNotification', this.onNotification);
     }
 
-    if (this.meeting == null) return;
+    if (!this.meeting) return;
     this.clearListeners(this.meeting);
     this.waitlistedParticipantJoinedListener &&
       this.meeting.participants.waitlisted.removeListener(
@@ -174,8 +176,8 @@ export class RtkNotifications {
   @Watch('meeting')
   meetingChanged(meeting: Meeting, oldMeeting?: Meeting) {
     clearTimeout(this.disconnectTimeout);
-    if (oldMeeting !== undefined) this.clearListeners(oldMeeting);
-    if (meeting == null) return;
+    if (oldMeeting) this.clearListeners(oldMeeting);
+    if (!meeting) return;
     const isLivestream = meeting.meta.viewType === 'LIVESTREAM';
     this.audio = new RTKNotificationsAudio(meeting);
     const { notifications, notification_duration, notification_sounds } = this.permissions;
@@ -655,6 +657,10 @@ export class RtkNotifications {
   paused = false;
 
   render() {
+    if (!this.meeting) {
+      return;
+    }
+
     return (
       <Host>
         <div

--- a/packages/core/src/components/rtk-notifications/rtk-notifications.tsx
+++ b/packages/core/src/components/rtk-notifications/rtk-notifications.tsx
@@ -104,7 +104,7 @@ export class RtkNotifications {
   t: RtkI18n = useLanguage();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-participant-count/rtk-participant-count.tsx
+++ b/packages/core/src/components/rtk-participant-count/rtk-participant-count.tsx
@@ -35,7 +35,7 @@ export class RtkParticipantCount {
   t: RtkI18n = useLanguage();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   @State() participantCount: number = 0;
 

--- a/packages/core/src/components/rtk-participant-setup/rtk-participant-setup.tsx
+++ b/packages/core/src/components/rtk-participant-setup/rtk-participant-setup.tsx
@@ -4,7 +4,7 @@ import { RtkI18n, useLanguage } from '../../lib/lang';
 import { Peer } from '../../types/rtk-client';
 import { Size, States } from '../../types/props';
 import { UIConfig } from '../../types/ui-config';
-import { defaultConfig } from '../../exports';
+import { createDefaultConfig } from '../../exports';
 import { SyncWithStore } from '../../utils/sync-with-store';
 import { RTKSelf } from '@cloudflare/realtimekit';
 
@@ -43,7 +43,9 @@ export class RtkParticipantSetup {
   states: States;
 
   /** Config object */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Variant */
   @Prop({ reflect: true }) variant: 'solid' | 'gradient' = 'solid';

--- a/packages/core/src/components/rtk-participant-setup/rtk-participant-setup.tsx
+++ b/packages/core/src/components/rtk-participant-setup/rtk-participant-setup.tsx
@@ -51,7 +51,7 @@ export class RtkParticipantSetup {
   @Prop({ reflect: true }) variant: 'solid' | 'gradient' = 'solid';
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-participant-tile/rtk-participant-tile.tsx
+++ b/packages/core/src/components/rtk-participant-tile/rtk-participant-tile.tsx
@@ -62,7 +62,7 @@ export class RtkParticipantTile {
   @Prop({ reflect: true }) variant: 'solid' | 'gradient' = 'solid';
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-participant-tile/rtk-participant-tile.tsx
+++ b/packages/core/src/components/rtk-participant-tile/rtk-participant-tile.tsx
@@ -5,7 +5,7 @@ import { Meeting, Peer } from '../../types/rtk-client';
 import { Size, States } from '../../types/props';
 import { UIConfig } from '../../types/ui-config';
 import { FlagsmithFeatureFlags } from '../../utils/flags';
-import { defaultConfig } from '../../exports';
+import { createDefaultConfig } from '../../exports';
 import { DefaultProps, Render } from '../../lib/render';
 import { SyncWithStore } from '../../utils/sync-with-store';
 import { RTKParticipant } from '@cloudflare/realtimekit';
@@ -54,7 +54,9 @@ export class RtkParticipantTile {
   states: States;
 
   /** Config object */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Variant */
   @Prop({ reflect: true }) variant: 'solid' | 'gradient' = 'solid';
@@ -176,6 +178,7 @@ export class RtkParticipantTile {
   };
 
   render() {
+    if (!this.meeting) return null;
     const defaults: DefaultProps = {
       meeting: this.meeting,
       size: this.size,

--- a/packages/core/src/components/rtk-participant/rtk-participant.tsx
+++ b/packages/core/src/components/rtk-participant/rtk-participant.tsx
@@ -14,7 +14,7 @@ import { RtkI18n, useLanguage } from '../../lib/lang';
 import { DefaultProps, lenChildren, Render } from '../../lib/render';
 import { Meeting, Participant, Peer } from '../../types/rtk-client';
 import { formatName, shorten } from '../../utils/string';
-import { defaultConfig, States, UIConfig } from '../../exports';
+import { createDefaultConfig, States, UIConfig } from '../../exports';
 import { FlagsmithFeatureFlags } from '../../utils/flags';
 import { autoPlacement, computePosition, hide, offset, shift } from '@floating-ui/dom';
 import { SyncWithStore } from '../../utils/sync-with-store';
@@ -78,7 +78,9 @@ export class RtkParticipant {
   t: RtkI18n = useLanguage();
 
   /** Config object */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /**
    * Emit notifications

--- a/packages/core/src/components/rtk-participants-audio/rtk-participants-audio.tsx
+++ b/packages/core/src/components/rtk-participants-audio/rtk-participants-audio.tsx
@@ -57,7 +57,7 @@ export class RtkParticipantsAudio {
   }
 
   disconnectedCallback() {
-    if (this.meeting == null) return;
+    if (!this.meeting) return;
 
     this.audioUpdateListener &&
       this.meeting.participants.joined.removeListener('audioUpdate', this.audioUpdateListener);
@@ -145,7 +145,7 @@ export class RtkParticipantsAudio {
 
   @Watch('meeting')
   async meetingChanged(meeting: Meeting) {
-    if (meeting == null) return;
+    if (!meeting) return;
     this.setupAudio();
     if (isLiveStreamViewer(meeting)) {
       this.stageStatusUpdateListener = async (status: StageStatus) => {

--- a/packages/core/src/components/rtk-participants-stage-list/rtk-participants-stage-list.tsx
+++ b/packages/core/src/components/rtk-participants-stage-list/rtk-participants-stage-list.tsx
@@ -38,7 +38,7 @@ export class RtkParticipants {
   config: UIConfig = createDefaultConfig();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Hide Stage Participants Count Header */
   @Prop() hideHeader: boolean = false;

--- a/packages/core/src/components/rtk-participants-stage-list/rtk-participants-stage-list.tsx
+++ b/packages/core/src/components/rtk-participants-stage-list/rtk-participants-stage-list.tsx
@@ -5,7 +5,7 @@ import { UIConfig } from '../../types/ui-config';
 import { Component, Host, h, Prop, State, Watch } from '@stencil/core';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { ParticipantsViewMode } from '../rtk-participants/rtk-participants';
-import { defaultConfig, States } from '../../exports';
+import { createDefaultConfig, States } from '../../exports';
 import { Render } from '../../lib/render';
 import { SyncWithStore } from '../../utils/sync-with-store';
 
@@ -33,7 +33,9 @@ export class RtkParticipants {
   states: States;
 
   /** Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Size */
   @SyncWithStore() @Prop({ reflect: true }) size: Size;
@@ -65,8 +67,8 @@ export class RtkParticipants {
   }
 
   disconnectedCallback() {
+    if (!this.meeting) return;
     const { participants, stage } = this.meeting;
-    if (this.meeting == null) return;
     this.participantJoinedListener &&
       this.meeting.participants.joined.removeListener(
         'participantJoined',
@@ -83,7 +85,7 @@ export class RtkParticipants {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting == null) return;
+    if (!meeting) return;
 
     this.participantJoinedListener = (participant: Participant) => {
       if (participant.stageStatus !== 'ON_STAGE') return;

--- a/packages/core/src/components/rtk-participants-stage-queue/rtk-participants-stage-queue.tsx
+++ b/packages/core/src/components/rtk-participants-stage-queue/rtk-participants-stage-queue.tsx
@@ -1,5 +1,12 @@
 import { Component, h, Prop, State, Watch } from '@stencil/core';
-import { UIConfig, Size, IconPack, defaultIconPack, RtkI18n, defaultConfig } from '../../exports';
+import {
+  UIConfig,
+  Size,
+  IconPack,
+  defaultIconPack,
+  RtkI18n,
+  createDefaultConfig,
+} from '../../exports';
 import { useLanguage } from '../../lib/lang';
 import { Meeting, Participant, Peer } from '../../types/rtk-client';
 import { SyncWithStore } from '../../utils/sync-with-store';
@@ -17,7 +24,9 @@ export class RtkParticipantsStaged {
   meeting: Meeting;
 
   /** Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Size */
   @SyncWithStore() @Prop({ reflect: true }) size: Size;
@@ -52,7 +61,7 @@ export class RtkParticipantsStaged {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting == null) return;
+    if (!meeting) return;
 
     this.updateRequestList();
     meeting.participants.joined.on('stageStatusUpdate', this.updateStageRequestedParticipants);
@@ -125,6 +134,7 @@ export class RtkParticipantsStaged {
   };
 
   render() {
+    if (!this.meeting) return null;
     if (this.view !== 'sidebar' || !this.shouldShowStageRequests()) return;
     return (
       <div class="stage-requested-participants">

--- a/packages/core/src/components/rtk-participants-stage-queue/rtk-participants-stage-queue.tsx
+++ b/packages/core/src/components/rtk-participants-stage-queue/rtk-participants-stage-queue.tsx
@@ -29,7 +29,7 @@ export class RtkParticipantsStaged {
   config: UIConfig = createDefaultConfig();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-participants-toggle/rtk-participants-toggle.tsx
+++ b/packages/core/src/components/rtk-participants-toggle/rtk-participants-toggle.tsx
@@ -39,7 +39,7 @@ export class RtkParticipantsToggle {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-participants-toggle/rtk-participants-toggle.tsx
+++ b/packages/core/src/components/rtk-participants-toggle/rtk-participants-toggle.tsx
@@ -65,7 +65,7 @@ export class RtkParticipantsToggle {
   }
 
   disconnectedCallback() {
-    if (this.meeting == null) return;
+    if (!this.meeting) return;
     this.meeting?.stage?.removeListener('stageStatusUpdate', this.updateCanView);
     this.waitlistedParticipantJoinedListener &&
       this.meeting.participants.waitlisted.removeListener(
@@ -100,7 +100,7 @@ export class RtkParticipantsToggle {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting == null) return;
+    if (!meeting) return;
     this.canViewParticipants = canViewParticipants(meeting);
     meeting?.stage?.on('stageStatusUpdate', this.updateCanView);
     if (meeting.self.permissions.acceptWaitingRequests) {

--- a/packages/core/src/components/rtk-participants-viewer-list/rtk-participants-viewer-list.tsx
+++ b/packages/core/src/components/rtk-participants-viewer-list/rtk-participants-viewer-list.tsx
@@ -1,5 +1,12 @@
 import { Component, h, Prop, State, Watch } from '@stencil/core';
-import { UIConfig, Size, IconPack, defaultIconPack, RtkI18n, defaultConfig } from '../../exports';
+import {
+  UIConfig,
+  Size,
+  IconPack,
+  defaultIconPack,
+  RtkI18n,
+  createDefaultConfig,
+} from '../../exports';
 import { useLanguage } from '../../lib/lang';
 import { Meeting, Participant, Peer } from '../../types/rtk-client';
 import { SyncWithStore } from '../../utils/sync-with-store';
@@ -23,7 +30,9 @@ export class RtkParticipantsViewers {
   meeting: Meeting;
 
   /** Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Size */
   @SyncWithStore() @Prop({ reflect: true }) size: Size;
@@ -55,7 +64,7 @@ export class RtkParticipantsViewers {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting == null) return;
+    if (!meeting) return;
 
     this.participantJoinedListener = (participant: Participant) => {
       if (participant.stageStatus === 'ON_STAGE') return;
@@ -136,6 +145,7 @@ export class RtkParticipantsViewers {
   };
 
   render() {
+    if (!this.meeting) return null;
     if (this.view !== 'sidebar' || !this.shouldShowViewers()) return;
 
     return (

--- a/packages/core/src/components/rtk-participants-viewer-list/rtk-participants-viewer-list.tsx
+++ b/packages/core/src/components/rtk-participants-viewer-list/rtk-participants-viewer-list.tsx
@@ -35,7 +35,7 @@ export class RtkParticipantsViewers {
   config: UIConfig = createDefaultConfig();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Hide Viewer Count Header */
   @Prop() hideHeader: boolean = false;

--- a/packages/core/src/components/rtk-participants-waiting-list/rtk-participants-waiting-list.tsx
+++ b/packages/core/src/components/rtk-participants-waiting-list/rtk-participants-waiting-list.tsx
@@ -32,7 +32,7 @@ export class RtkParticipantsWaitlisted {
   config: UIConfig = createDefaultConfig();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-participants-waiting-list/rtk-participants-waiting-list.tsx
+++ b/packages/core/src/components/rtk-participants-waiting-list/rtk-participants-waiting-list.tsx
@@ -1,5 +1,12 @@
 import { Component, h, Prop, State, Watch } from '@stencil/core';
-import { UIConfig, Size, IconPack, defaultIconPack, RtkI18n, defaultConfig } from '../../exports';
+import {
+  UIConfig,
+  Size,
+  IconPack,
+  defaultIconPack,
+  RtkI18n,
+  createDefaultConfig,
+} from '../../exports';
 import { useLanguage } from '../../lib/lang';
 import { Meeting, WaitlistedParticipant } from '../../types/rtk-client';
 import { SyncWithStore } from '../../utils/sync-with-store';
@@ -20,7 +27,9 @@ export class RtkParticipantsWaitlisted {
   @Prop()
   meeting: Meeting;
   /** Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Size */
   @SyncWithStore() @Prop({ reflect: true }) size: Size;
@@ -79,7 +88,7 @@ export class RtkParticipantsWaitlisted {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting == null) return;
+    if (!meeting) return;
     this.waitlistedParticipants = meeting.participants.waitlisted.toArray();
 
     this.waitlistedParticipantJoinedListener = (participant: WaitlistedParticipant) => {

--- a/packages/core/src/components/rtk-participants/rtk-participants.tsx
+++ b/packages/core/src/components/rtk-participants/rtk-participants.tsx
@@ -43,7 +43,7 @@ export class RtkParticipants {
   config: UIConfig = createDefaultConfig();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-participants/rtk-participants.tsx
+++ b/packages/core/src/components/rtk-participants/rtk-participants.tsx
@@ -4,7 +4,7 @@ import { Size, States } from '../../types/props';
 import { UIConfig } from '../../types/ui-config';
 import { Component, Host, h, Prop, State, Watch, Event, EventEmitter } from '@stencil/core';
 import { RtkI18n, useLanguage } from '../../lib/lang';
-import { defaultConfig } from '../../exports';
+import { createDefaultConfig } from '../../exports';
 import { SyncWithStore } from '../../utils/sync-with-store';
 import { debounce } from 'lodash-es';
 
@@ -38,7 +38,9 @@ export class RtkParticipants {
   states: States;
 
   /** Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Size */
   @SyncWithStore() @Prop({ reflect: true }) size: Size;
@@ -72,7 +74,7 @@ export class RtkParticipants {
   }
 
   disconnectedCallback() {
-    if (this.meeting == null) return;
+    if (!this.meeting) return;
     this.meeting.participants.joined.off('participantJoined', this.updateParticipantCountsInTabs);
     this.meeting.participants.joined.off('participantsUpdate', this.updateParticipantCountsInTabs);
     this.meeting.participants.joined.off('participantLeft', this.updateParticipantCountsInTabs);
@@ -91,7 +93,7 @@ export class RtkParticipants {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting == null) return;
+    if (!meeting) return;
     meeting.participants.joined.on('participantJoined', this.updateParticipantCountsInTabs);
     meeting.participants.joined.on('participantsUpdate', this.updateParticipantCountsInTabs);
     meeting.participants.joined.on('participantLeft', this.updateParticipantCountsInTabs);
@@ -232,6 +234,7 @@ export class RtkParticipants {
   };
 
   render() {
+    if (!this.meeting) return null;
     const defaults = {
       meeting: this.meeting,
       states: this.states,

--- a/packages/core/src/components/rtk-pip-toggle/rtk-pip-toggle.tsx
+++ b/packages/core/src/components/rtk-pip-toggle/rtk-pip-toggle.tsx
@@ -42,7 +42,7 @@ export class RtkPipToggle {
   iconPack: IconPack = defaultIconPack;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Language */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-pip-toggle/rtk-pip-toggle.tsx
+++ b/packages/core/src/components/rtk-pip-toggle/rtk-pip-toggle.tsx
@@ -1,5 +1,12 @@
 import { Component, Host, h, Event, EventEmitter, Prop, Watch, State } from '@stencil/core';
-import { defaultConfig, defaultIconPack, IconPack, Size, States, UIConfig } from '../../exports';
+import {
+  createDefaultConfig,
+  defaultIconPack,
+  IconPack,
+  Size,
+  States,
+  UIConfig,
+} from '../../exports';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { Meeting } from '../../types/rtk-client';
 import { ControlBarVariant } from '../rtk-controlbar-button/rtk-controlbar-button';
@@ -25,7 +32,9 @@ export class RtkPipToggle {
   states: States;
 
   /** Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Icon pack */
   @SyncWithStore()
@@ -72,6 +81,7 @@ export class RtkPipToggle {
   }
 
   render() {
+    if (!this.meeting) return null;
     if (!this.pipSupported) return <Host data-hidden />;
     const pipEnabled = this.meeting.participants.pip.isActive;
     return (

--- a/packages/core/src/components/rtk-plugins-toggle/rtk-plugins-toggle.tsx
+++ b/packages/core/src/components/rtk-plugins-toggle/rtk-plugins-toggle.tsx
@@ -64,7 +64,7 @@ export class RtkPluginsToggle {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting == null) return;
+    if (!meeting) return;
     this.canViewPlugins = canViewPlugins(meeting);
     meeting?.stage?.on('stageStatusUpdate', this.updateCanView);
     meeting?.self?.permissions.addListener('pluginsUpdate', this.updateCanView);

--- a/packages/core/src/components/rtk-plugins-toggle/rtk-plugins-toggle.tsx
+++ b/packages/core/src/components/rtk-plugins-toggle/rtk-plugins-toggle.tsx
@@ -36,7 +36,7 @@ export class RtkPluginsToggle {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-plugins/rtk-plugins.tsx
+++ b/packages/core/src/components/rtk-plugins/rtk-plugins.tsx
@@ -6,7 +6,7 @@ import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RTKPlugin } from '@cloudflare/realtimekit';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { SyncWithStore } from '../../utils/sync-with-store';
-import { defaultConfig } from '../../exports';
+import { createDefaultConfig } from '../../exports';
 
 /**
  * A component which lists all available plugins from their preset,
@@ -25,7 +25,9 @@ export class RtkPlugins {
   meeting: Meeting;
 
   /** Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Size */
   @SyncWithStore() @Prop({ reflect: true }) size: Size;

--- a/packages/core/src/components/rtk-plugins/rtk-plugins.tsx
+++ b/packages/core/src/components/rtk-plugins/rtk-plugins.tsx
@@ -30,7 +30,7 @@ export class RtkPlugins {
   config: UIConfig = createDefaultConfig();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-polls-toggle/rtk-polls-toggle.tsx
+++ b/packages/core/src/components/rtk-polls-toggle/rtk-polls-toggle.tsx
@@ -38,7 +38,7 @@ export class RtkPollsToggle {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-polls/rtk-polls.tsx
+++ b/packages/core/src/components/rtk-polls/rtk-polls.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop, Watch, State } from '@stencil/core';
-import { defaultConfig } from '../../exports';
+import { createDefaultConfig } from '../../exports';
 import { IconPack, defaultIconPack } from '../../lib/icons';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { Meeting } from '../../types/rtk-client';
@@ -29,7 +29,9 @@ export class RtkPolls {
   meeting: Meeting;
 
   /** Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Size */
   @SyncWithStore() @Prop({ reflect: true }) size: Size;
@@ -57,7 +59,7 @@ export class RtkPolls {
   }
 
   disconnectedCallback() {
-    if (this.meeting == null) return;
+    if (!this.meeting) return;
     this.meeting.polls?.removeListener('pollsUpdate', this.onPollsUpdate);
     this.meeting.self.permissions.removeListener('pollsUpdate', this.onUpdatePermissions);
   }

--- a/packages/core/src/components/rtk-polls/rtk-polls.tsx
+++ b/packages/core/src/components/rtk-polls/rtk-polls.tsx
@@ -34,7 +34,7 @@ export class RtkPolls {
   config: UIConfig = createDefaultConfig();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-recording-indicator/rtk-recording-indicator.tsx
+++ b/packages/core/src/components/rtk-recording-indicator/rtk-recording-indicator.tsx
@@ -25,7 +25,7 @@ export class RtkRecordingIndicator {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Language */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-recording-toggle/rtk-recording-toggle.tsx
+++ b/packages/core/src/components/rtk-recording-toggle/rtk-recording-toggle.tsx
@@ -166,13 +166,12 @@ export class RtkRecordingToggle {
 
   private isLoading = () => {
     return (
-      this.meeting == null ||
-      this.recordingState === 'STARTING' ||
-      this.recordingState === 'STOPPING'
+      !this.meeting || this.recordingState === 'STARTING' || this.recordingState === 'STOPPING'
     );
   };
 
   render() {
+    if (!this.meeting) return null;
     if (!this.canRecord) return;
     return (
       <Host

--- a/packages/core/src/components/rtk-recording-toggle/rtk-recording-toggle.tsx
+++ b/packages/core/src/components/rtk-recording-toggle/rtk-recording-toggle.tsx
@@ -41,7 +41,7 @@ export class RtkRecordingToggle {
   iconPack: IconPack = defaultIconPack;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Disable the button */
   @Prop() disabled: boolean = false;

--- a/packages/core/src/components/rtk-screen-share-toggle/rtk-screen-share-toggle.tsx
+++ b/packages/core/src/components/rtk-screen-share-toggle/rtk-screen-share-toggle.tsx
@@ -50,7 +50,7 @@ export class RtkScreenShareToggle {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-screenshare-view/rtk-screenshare-view.tsx
+++ b/packages/core/src/components/rtk-screenshare-view/rtk-screenshare-view.tsx
@@ -76,7 +76,7 @@ export class RtkScreenshareView {
   @Prop({ reflect: true }) variant: 'solid' | 'gradient' = 'solid';
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-settings-audio/rtk-settings-audio.tsx
+++ b/packages/core/src/components/rtk-settings-audio/rtk-settings-audio.tsx
@@ -35,7 +35,7 @@ export class RtkSettingsAudio {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-settings-audio/rtk-settings-audio.tsx
+++ b/packages/core/src/components/rtk-settings-audio/rtk-settings-audio.tsx
@@ -51,7 +51,7 @@ export class RtkSettingsAudio {
   @Event({ eventName: 'rtkStateUpdate' }) stateUpdate: EventEmitter<States>;
 
   render() {
-    if (this.meeting == null) return null;
+    if (!this.meeting) return null;
 
     const defaults = {
       meeting: this.meeting,

--- a/packages/core/src/components/rtk-settings-toggle/rtk-settings-toggle.tsx
+++ b/packages/core/src/components/rtk-settings-toggle/rtk-settings-toggle.tsx
@@ -29,7 +29,7 @@ export class RtkSettingsToggle {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-settings-video/rtk-settings-video.tsx
+++ b/packages/core/src/components/rtk-settings-video/rtk-settings-video.tsx
@@ -58,7 +58,7 @@ export class RtkSettingsVideo {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting == null) return;
+    if (!meeting) return;
 
     this.videoEnabled = meeting.self.videoEnabled;
     meeting.self?.addListener('videoUpdate', this.onVideoUpdate);
@@ -73,7 +73,7 @@ export class RtkSettingsVideo {
   };
 
   render() {
-    if (this.meeting == null) return null;
+    if (!this.meeting) return null;
 
     const defaults = {
       meeting: this.meeting,

--- a/packages/core/src/components/rtk-settings-video/rtk-settings-video.tsx
+++ b/packages/core/src/components/rtk-settings-video/rtk-settings-video.tsx
@@ -35,7 +35,7 @@ export class RtkSettingsVideo {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-settings/rtk-settings.tsx
+++ b/packages/core/src/components/rtk-settings/rtk-settings.tsx
@@ -117,7 +117,7 @@ export class RtkSettings {
   }
 
   render() {
-    if (this.meeting == null) return null;
+    if (!this.meeting) return null;
 
     const defaults = {
       meeting: this.meeting,

--- a/packages/core/src/components/rtk-settings/rtk-settings.tsx
+++ b/packages/core/src/components/rtk-settings/rtk-settings.tsx
@@ -39,7 +39,7 @@ export class RtkSettings {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.tsx
+++ b/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.tsx
@@ -43,7 +43,7 @@ export class RtkSetupScreen {
   states: States;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Config object */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.tsx
+++ b/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.tsx
@@ -13,7 +13,7 @@ import { Meeting } from '../../types/rtk-client';
 import { Size, States } from '../../types/props';
 import { shorten } from '../../utils/string';
 import { UIConfig } from '../../types/ui-config';
-import { defaultConfig } from '../../lib/default-ui-config';
+import { createDefaultConfig } from '../../lib/default-ui-config';
 import { Render } from '../../lib/render';
 import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RtkI18n, useLanguage } from '../../lib/lang';
@@ -46,7 +46,9 @@ export class RtkSetupScreen {
   @SyncWithStore() @Prop({ reflect: true }) size: Size;
 
   /** Config object */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Emits updated state data */
   @Event({ eventName: 'rtkStateUpdate' }) stateUpdate: EventEmitter<States>;
@@ -113,6 +115,10 @@ export class RtkSetupScreen {
   };
 
   render() {
+    if (!this.meeting) {
+      return;
+    }
+
     const disabled =
       this.displayName?.trim() === '' || this.connectionState !== 'connected' || this.isJoining;
 

--- a/packages/core/src/components/rtk-sidebar/rtk-sidebar.tsx
+++ b/packages/core/src/components/rtk-sidebar/rtk-sidebar.tsx
@@ -62,7 +62,7 @@ export class RtkSidebar {
   t: RtkI18n = useLanguage();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** View type */
   @Prop({ reflect: true }) view: RtkSidebarView = 'sidebar';

--- a/packages/core/src/components/rtk-sidebar/rtk-sidebar.tsx
+++ b/packages/core/src/components/rtk-sidebar/rtk-sidebar.tsx
@@ -4,7 +4,7 @@ import { Size, States } from '../../types/props';
 import { UIConfig } from '../../types/ui-config';
 import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RtkI18n, useLanguage } from '../../lib/lang';
-import { defaultConfig } from '../../lib/default-ui-config';
+import { createDefaultConfig } from '../../lib/default-ui-config';
 import {
   canViewChat,
   canViewParticipants,
@@ -47,7 +47,9 @@ export class RtkSidebar {
   states: States;
 
   /** Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Icon pack */
   @SyncWithStore()
@@ -88,6 +90,9 @@ export class RtkSidebar {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
+    if (!meeting) {
+      return;
+    }
     this.updateEnabledSections(meeting);
     this.onStageStatusUpdate = (_status: StageStatus) => {
       this.updateEnabledSections(this.meeting);
@@ -154,6 +159,10 @@ export class RtkSidebar {
   };
 
   render() {
+    if (!this.meeting) {
+      return null;
+    }
+
     const defaults = {
       meeting: this.meeting,
       config: this.config,

--- a/packages/core/src/components/rtk-simple-grid/rtk-simple-grid.tsx
+++ b/packages/core/src/components/rtk-simple-grid/rtk-simple-grid.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop, Element, State, Watch } from '@stencil/core';
-import { defaultConfig } from '../../lib/default-ui-config';
+import { createDefaultConfig } from '../../lib/default-ui-config';
 import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { Render } from '../../lib/render';
@@ -49,7 +49,9 @@ export class RtkSimpleGrid {
   states: States;
 
   /** UI Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Icon Pack */
   @SyncWithStore()
@@ -89,6 +91,7 @@ export class RtkSimpleGrid {
   }
 
   render() {
+    if (!this.meeting) return null;
     const defaults = {
       meeting: this.meeting,
       config: this.config,

--- a/packages/core/src/components/rtk-simple-grid/rtk-simple-grid.tsx
+++ b/packages/core/src/components/rtk-simple-grid/rtk-simple-grid.tsx
@@ -36,7 +36,7 @@ export class RtkSimpleGrid {
   @Prop() gap: number = 8;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Meeting object */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-speaker-selector/rtk-speaker-selector.tsx
+++ b/packages/core/src/components/rtk-speaker-selector/rtk-speaker-selector.tsx
@@ -91,7 +91,7 @@ export class RtkSpeakerSelector {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting == null) return;
+    if (!meeting) return;
 
     writeTask(async () => {
       const { self } = meeting;
@@ -136,7 +136,7 @@ export class RtkSpeakerSelector {
   }
 
   render() {
-    if (this.meeting == null) return null;
+    if (!this.meeting) return null;
 
     let unnamedSpeakerCount = 0;
     return (

--- a/packages/core/src/components/rtk-speaker-selector/rtk-speaker-selector.tsx
+++ b/packages/core/src/components/rtk-speaker-selector/rtk-speaker-selector.tsx
@@ -42,7 +42,7 @@ export class RtkSpeakerSelector {
   @Prop() variant: 'full' | 'inline' = 'full';
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-spinner/rtk-spinner.tsx
+++ b/packages/core/src/components/rtk-spinner/rtk-spinner.tsx
@@ -18,7 +18,7 @@ export class RtkSpinner {
   iconPack: IconPack = defaultIconPack;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size = 'md';
+  @Prop({ reflect: true }) size: Size = 'md';
 
   render() {
     return (

--- a/packages/core/src/components/rtk-spotlight-grid/rtk-spotlight-grid.tsx
+++ b/packages/core/src/components/rtk-spotlight-grid/rtk-spotlight-grid.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop, Element } from '@stencil/core';
-import { defaultConfig } from '../../lib/default-ui-config';
+import { createDefaultConfig } from '../../lib/default-ui-config';
 import { defaultGridSize } from '../../lib/grid';
 import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RtkI18n, useLanguage } from '../../lib/lang';
@@ -57,7 +57,9 @@ export class RtkSpotlightGrid {
   states: States;
 
   /** UI Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Icon Pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-spotlight-grid/rtk-spotlight-grid.tsx
+++ b/packages/core/src/components/rtk-spotlight-grid/rtk-spotlight-grid.tsx
@@ -44,7 +44,7 @@ export class RtkSpotlightGrid {
   @Prop() gap: number = 8;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Meeting object */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-spotlight-indicator/rtk-spotlight-indicator.tsx
+++ b/packages/core/src/components/rtk-spotlight-indicator/rtk-spotlight-indicator.tsx
@@ -27,7 +27,7 @@ export class RtkSpotlightIndicator {
   t: RtkI18n = useLanguage();
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   @State() canSpotlight: boolean;
 

--- a/packages/core/src/components/rtk-stage-toggle/rtk-stage-toggle.tsx
+++ b/packages/core/src/components/rtk-stage-toggle/rtk-stage-toggle.tsx
@@ -28,7 +28,7 @@ export class RtkStageToggle {
   meeting: Meeting;
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-stage-toggle/rtk-stage-toggle.tsx
+++ b/packages/core/src/components/rtk-stage-toggle/rtk-stage-toggle.tsx
@@ -6,7 +6,6 @@ import { Meeting } from '../../types/rtk-client';
 import { canRequestToJoinStage, canJoinStage } from '../../utils/stage';
 import { ControlBarVariant } from '../rtk-controlbar-button/rtk-controlbar-button';
 import { SyncWithStore } from '../../utils/sync-with-store';
-import { uiState } from '../../utils/sync-with-store/ui-store';
 
 interface DataState {
   label: string;
@@ -78,7 +77,7 @@ export class RtkStageToggle {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting == null) return;
+    if (!meeting) return;
     this.stageStatus = meeting.stage?.status;
     this.stageStatusHandler(meeting, meeting.stage?.status);
     this.meeting?.stage?.on('stageStatusUpdate', (status) =>
@@ -95,7 +94,7 @@ export class RtkStageToggle {
     if (stageStatus === 'OFF_STAGE') {
       this?.meeting?.stage?.requestAccess();
       if (canJoinStage(this.meeting)) {
-        uiState.states.activeJoinStage = true;
+        this.states.activeJoinStage = true;
         this.stateUpdate.emit({ activeJoinStage: true });
       }
     }

--- a/packages/core/src/components/rtk-tab-bar/rtk-tab-bar.tsx
+++ b/packages/core/src/components/rtk-tab-bar/rtk-tab-bar.tsx
@@ -24,7 +24,7 @@ export interface Tab {
 })
 export class RtkTabBar {
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Meeting object */
   @SyncWithStore()

--- a/packages/core/src/components/rtk-tab-bar/rtk-tab-bar.tsx
+++ b/packages/core/src/components/rtk-tab-bar/rtk-tab-bar.tsx
@@ -1,7 +1,7 @@
 import { Component, Host, h, Prop, Event, EventEmitter } from '@stencil/core';
 import { RTKPlugin } from '@cloudflare/realtimekit';
 import type { ActiveTabType } from '@cloudflare/realtimekit';
-import { defaultConfig } from '../../lib/default-ui-config';
+import { createDefaultConfig } from '../../lib/default-ui-config';
 import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { Meeting, Peer } from '../../types/rtk-client';
@@ -37,7 +37,9 @@ export class RtkTabBar {
   states: States;
 
   /** UI Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Grid Layout */
   @Prop({ reflect: true }) layout: GridLayout = 'row';

--- a/packages/core/src/components/rtk-tooltip/rtk-tooltip.tsx
+++ b/packages/core/src/components/rtk-tooltip/rtk-tooltip.tsx
@@ -12,7 +12,6 @@ import {
 import { arrow, computePosition, flip, offset, shift } from '@floating-ui/dom';
 import { Size } from '../../types/props';
 import { Placement } from '../../types/floating-ui';
-import { SyncWithStore } from '../../utils/sync-with-store';
 
 export type TooltipVariant = 'primary' | 'secondary';
 export type TooltipKind = 'inline' | 'block';
@@ -49,7 +48,7 @@ export class RtkMenu {
   @Prop({ reflect: true }) kind: TooltipKind = 'inline';
 
   /** Size */
-  @SyncWithStore() @Prop({ reflect: true }) size: Size;
+  @Prop({ reflect: true }) size: Size;
 
   /** Placement of menu */
   @Prop() placement: Placement = 'top';

--- a/packages/core/src/components/rtk-transcripts/rtk-transcripts.tsx
+++ b/packages/core/src/components/rtk-transcripts/rtk-transcripts.tsx
@@ -4,7 +4,7 @@ import { Meeting } from '../../types/rtk-client';
 import { Transcript, States } from '../../types/props';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { UIConfig } from '../../types/ui-config';
-import { defaultConfig } from '../../exports';
+import { createDefaultConfig } from '../../exports';
 import { SyncWithStore } from '../../utils/sync-with-store';
 import clone from '../../utils/clone';
 
@@ -35,7 +35,9 @@ export class RtkTranscripts {
   states: States;
 
   /** Config object */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Language */
   @SyncWithStore()
@@ -63,15 +65,15 @@ export class RtkTranscripts {
   }
 
   disconnectedCallback() {
-    if (this.meeting == null) return;
+    if (!this.meeting) return;
     this.clearListeners(this.meeting);
   }
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting, oldMeeting?: Meeting) {
     clearTimeout(this.disconnectTimeout);
-    if (oldMeeting !== undefined) this.clearListeners(oldMeeting);
-    if (meeting == null) return;
+    if (oldMeeting) this.clearListeners(oldMeeting);
+    if (!meeting) return;
 
     if (this.states.activeCaptions) {
       this.addListener(meeting);

--- a/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.css
+++ b/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.css
@@ -1,5 +1,15 @@
-rtk-ui-provider {
-  display: block;
-  width: 100%;
-  height: 100%;
+@import '../../styles/reset.css';
+
+:host {
+  @apply box-border flex flex-col;
+  @apply bg-background-1000 text-text-900;
+
+  @apply overflow-hidden;
+
+  /* fixed `mode` by default */
+  @apply fixed inset-0 h-full w-full;
+}
+
+:host([mode='fill']) {
+  @apply relative;
 }

--- a/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
+++ b/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
@@ -1,26 +1,21 @@
-import {
-  Component,
-  Element,
-  Event,
-  EventEmitter,
-  h,
-  Host,
-  Listen,
-  Prop,
-  Watch,
-} from '@stencil/core';
+import { Component, Element, Event, EventEmitter, h, Host, Prop, Watch } from '@stencil/core';
+import { MeetingMode } from '../rtk-meeting/rtk-meeting';
 import { Meeting, RoomLeftState } from '../../types/rtk-client';
 import {
-  defaultConfig,
+  createDefaultConfig,
   RtkI18n,
-  generateConfig,
   IconPack,
-  provideRtkDesignSystem,
   Size,
   States,
   UIConfig,
+  useLanguage,
+  defaultIconPack,
 } from '../../exports';
-import { uiState, uiStore } from '../../utils/sync-with-store/ui-store';
+import {
+  uiStore as legacyGlobalUIStore,
+  createPeerStore,
+  type RtkUiStoreExtended,
+} from '../../utils/sync-with-store/ui-store';
 import deepMerge from 'lodash-es/merge';
 import { PermissionSettings } from '../../types/props';
 import { getSize } from '../../utils/size';
@@ -34,20 +29,30 @@ const LEAVE_ROOM_TIMER = 10000;
 export class RtkUiProvider {
   @Element() host: HTMLRtkUiProviderElement;
 
+  private peerStore: RtkUiStoreExtended | null = null;
+
+  private providerId: string = 'provider-' + Math.floor(Math.random() * 100);
+
+  private storeRequestListener: (event: CustomEvent) => void;
+  private stateUpdateListener: (event: CustomEvent<States>) => void;
+
   /** Meeting */
   @Prop()
-  meeting: Meeting;
+  meeting: Meeting | null = null;
 
   /** Icon pack */
   @Prop()
-  iconPack: IconPack;
+  iconPack: IconPack = defaultIconPack;
 
   /** Language utility */
   @Prop()
-  t: RtkI18n;
+  t: RtkI18n = useLanguage();
 
   /** Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @Prop() config: UIConfig = createDefaultConfig();
+
+  /** Fill type */
+  @Prop({ reflect: true }) mode: MeetingMode = 'fixed';
 
   /** Size */
   @Prop({ reflect: true, mutable: true }) size: Size;
@@ -56,28 +61,14 @@ export class RtkUiProvider {
   @Prop() showSetupScreen: boolean = false;
 
   /**
-   * Do not render children until meeting is initialized
-   * @default false
+   * Emits `rtkStatesUpdate` so that developers can listen to onRtkStatesUpdate and update their own stores
+   * Do not confuse this with `rtkStateUpdate` that other components emit
    */
-  @Prop() noRenderUntilMeeting: boolean = false;
-
-  /** States event */
   @Event({ eventName: 'rtkStatesUpdate' }) statesUpdate: EventEmitter<States>;
 
   private authErrorListener: (ev: CustomEvent<Error>) => void;
 
   private resizeObserver: ResizeObserver;
-
-  @Listen('rtkStateUpdate')
-  listenState(e: CustomEvent<States>) {
-    this.updateStates(e.detail);
-  }
-
-  private updateStates(states: Partial<States>) {
-    const newStates = Object.assign({}, uiState.states);
-    uiState.states = deepMerge(newStates, states);
-    this.statesUpdate.emit(uiState.states);
-  }
 
   connectedCallback() {
     if (typeof window !== 'undefined') {
@@ -88,6 +79,9 @@ export class RtkUiProvider {
       };
       window.addEventListener('rtkError', this.authErrorListener);
     }
+
+    // Listen for store requests from child components
+    this.setupStoreRequestListener();
 
     this.onMeetingChange(this.meeting);
     this.onIconPackChange(this.iconPack);
@@ -103,6 +97,14 @@ export class RtkUiProvider {
     this.resizeObserver.disconnect();
     window.removeEventListener('rtkError', this.authErrorListener);
 
+    // Remove event listeners
+    if (this.storeRequestListener) {
+      this.host.removeEventListener('rtkRequestStore', this.storeRequestListener);
+    }
+    if (this.stateUpdateListener) {
+      this.host.removeEventListener('rtkStateUpdate', this.stateUpdateListener);
+    }
+
     if (!this.meeting) return;
     this.meeting.self.removeListener('roomLeft', this.roomLeftListener);
     this.meeting.self.removeListener('roomJoined', this.roomJoinedListener);
@@ -111,71 +113,149 @@ export class RtkUiProvider {
     this.meeting.meta.removeListener('socketConnectionUpdate', this.socketConnectionUpdateListener);
   }
 
+  private updateStates(states: Partial<States>) {
+    // Use peer specific store if available, otherwise fall back to global store
+    const targetStore = this.peerStore || legacyGlobalUIStore;
+    const newStates = Object.assign({}, targetStore.state.states);
+    targetStore.state.states = deepMerge(newStates, states);
+
+    // Emit unscoped event for backward compatibility
+    this.statesUpdate.emit(targetStore.state.states);
+
+    // Also emit a scoped event that only this meeting's components should listen to
+    const scopedEvent = new CustomEvent('rtkStatesUpdate', {
+      detail: targetStore.state.states,
+      bubbles: true,
+      composed: true,
+    });
+    this.host.dispatchEvent(scopedEvent);
+  }
+
+  private setupStateUpdateListener() {
+    // Remove existing listener if any
+    if (this.stateUpdateListener) {
+      this.host.removeEventListener('rtkStateUpdate', this.stateUpdateListener);
+    }
+
+    // Create new listener
+    this.stateUpdateListener = (event: CustomEvent<States>) => {
+      this.updateStates(event.detail);
+    };
+
+    // Listen for both generic events (backward compatibility) and peer-specific events
+    this.host.addEventListener('rtkStateUpdate', this.stateUpdateListener);
+  }
+
+  private setupStoreRequestListener() {
+    // Remove existing listener if any
+    if (this.storeRequestListener) {
+      this.host.removeEventListener('rtkRequestStore', this.storeRequestListener);
+    }
+
+    // Listen for store requests from child components
+    this.storeRequestListener = (
+      event: CustomEvent<{ element: HTMLElement; propName: string; requestId: string }>
+    ) => {
+      if (!this.peerStore) return;
+      // Provide the actual store object, not a wrapper
+
+      const responseEvent = new CustomEvent('rtkProvideStore', {
+        detail: { store: this.peerStore, requestId: event.detail.requestId },
+      });
+      document.dispatchEvent(responseEvent);
+
+      // Stop the event from bubbling further to prevent other providers from handling it
+      event.stopPropagation();
+    };
+
+    this.host.addEventListener('rtkRequestStore', this.storeRequestListener);
+  }
+
   @Watch('meeting')
   onMeetingChange(meeting: Meeting) {
-    uiStore.state.meeting = meeting;
+    if (meeting) {
+      this.peerStore = createPeerStore({
+        meeting,
+        config: this.config,
+        iconPack: this.iconPack,
+        t: this.t,
+        size: this.size,
+        providerId: this.providerId,
+      }) as RtkUiStoreExtended;
 
-    if (!meeting) return;
-
-    this.updateStates({ viewType: meeting.meta.viewType });
-    this.loadTheme();
-
-    meeting.self.addListener('roomJoined', this.roomJoinedListener);
-    meeting.self.addListener('waitlisted', this.waitlistedListener);
-    meeting.self.addListener('roomLeft', this.roomLeftListener);
-    meeting.self.addListener('mediaPermissionUpdate', this.mediaPermissionUpdateListener);
-    meeting.meta.addListener('socketConnectionUpdate', this.socketConnectionUpdateListener);
-
-    if (meeting.connectedMeetings.supportsConnectedMeetings) {
-      meeting.connectedMeetings.once('changingMeeting', this.handleChangingMeeting);
+      // Notify components that peer specific store is now available
+      document.dispatchEvent(
+        new CustomEvent('rtkPeerStoreReady', {
+          detail: {
+            peerId: meeting.self.id,
+          },
+        })
+      );
     }
 
-    if (meeting.self.roomJoined) {
-      this.updateStates({ meeting: 'joined' });
-    } else {
-      if (this.showSetupScreen) {
-        this.updateStates({ meeting: 'setup' });
-      } else {
-        meeting.joinRoom();
+    // Setup state update listener now that we have peerId
+    this.setupStateUpdateListener();
+
+    if (meeting) {
+      const targetStore = this.peerStore || legacyGlobalUIStore;
+      targetStore.state.meeting = meeting;
+
+      this.updateStates({ viewType: meeting.meta.viewType });
+
+      meeting.self.addListener('roomJoined', this.roomJoinedListener);
+      meeting.self.addListener('waitlisted', this.waitlistedListener);
+      meeting.self.addListener('roomLeft', this.roomLeftListener);
+      meeting.self.addListener('mediaPermissionUpdate', this.mediaPermissionUpdateListener);
+      meeting.meta.addListener('socketConnectionUpdate', this.socketConnectionUpdateListener);
+
+      if (meeting.connectedMeetings.supportsConnectedMeetings) {
+        meeting.connectedMeetings.once('changingMeeting', this.handleChangingMeeting);
       }
-    }
 
-    window.removeEventListener('rtkError', this.authErrorListener);
+      if (meeting.self.roomJoined) {
+        this.updateStates({ meeting: 'joined' });
+      } else {
+        if (this.showSetupScreen) {
+          this.updateStates({ meeting: 'setup' });
+        } else {
+          meeting.joinRoom();
+        }
+      }
+
+      window.removeEventListener('rtkError', this.authErrorListener);
+    }
   }
 
   @Watch('iconPack')
   onIconPackChange(newIconPack: IconPack) {
-    uiStore.state.iconPack = newIconPack;
+    if (this.peerStore) {
+      this.peerStore.state.iconPack = newIconPack;
+    }
   }
 
   @Watch('t')
   onTChange(newT: RtkI18n) {
-    uiStore.state.t = newT;
+    if (this.peerStore) {
+      this.peerStore.state.t = newT;
+    }
   }
 
   @Watch('config')
   onConfigChange(config: UIConfig) {
-    uiStore.state.config = config;
+    if (this.peerStore) {
+      this.peerStore.state.config = config;
+    }
   }
 
   @Watch('size')
   onSizeChange(newSize: Size) {
-    uiStore.state.size = newSize;
+    if (this.peerStore) {
+      this.peerStore.state.size = newSize;
+    }
   }
 
   private handleResize = () => {
     this.size = getSize(this.host.clientWidth);
-  };
-
-  private loadTheme = () => {
-    if (this.config === defaultConfig) {
-      const { config } = generateConfig(this.meeting.self.config, this.meeting);
-      this.config = config;
-    }
-
-    if (this.config?.designTokens) {
-      provideRtkDesignSystem(document.documentElement, this.config.designTokens);
-    }
   };
 
   private roomJoinedListener = () => {
@@ -187,7 +267,6 @@ export class RtkUiProvider {
   };
 
   private roomLeftListener = ({ state }: { state: RoomLeftState }) => {
-    // Let socketConnectionUpdate listener handle this case.
     if (state === 'disconnected' || state === 'failed') return;
     this.updateStates({ meeting: 'ended', roomLeftState: state });
   };
@@ -196,7 +275,7 @@ export class RtkUiProvider {
     if (['audio', 'video'].includes(kind)) {
       if (
         (message === 'DENIED' || message === 'SYSTEM_DENIED') &&
-        uiState.states.activeDebugger !== true
+        (this.peerStore || legacyGlobalUIStore).state.states.activeDebugger !== true
       ) {
         const permissionModalSettings: PermissionSettings = {
           enabled: true,
@@ -216,15 +295,25 @@ export class RtkUiProvider {
   };
 
   private handleChangingMeeting = (destinationMeetingId: string) => {
+    const currentStates = this.peerStore.state.states;
     this.updateStates({
       activeBreakoutRoomsManager: {
-        ...uiState.states.activeBreakoutRoomsManager,
+        ...currentStates.activeBreakoutRoomsManager,
         destinationMeetingId,
       },
     });
   };
 
   render() {
-    return <Host>{this.noRenderUntilMeeting && !this.meeting ? null : <slot />}</Host>;
+    // Don't render children until meeting is properly initialized
+    if (!this.meeting) {
+      return null;
+    }
+
+    return (
+      <Host>
+        <slot />
+      </Host>
+    );
   }
 }

--- a/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
+++ b/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
@@ -10,6 +10,7 @@ import {
   UIConfig,
   useLanguage,
   defaultIconPack,
+  provideRtkDesignSystem,
 } from '../../exports';
 import {
   uiStore as legacyGlobalUIStore,
@@ -244,6 +245,14 @@ export class RtkUiProvider {
   onConfigChange(config: UIConfig) {
     if (this.peerStore) {
       this.peerStore.state.config = config;
+    }
+
+    if (
+      config?.designTokens &&
+      typeof document !== 'undefined' &&
+      (this.peerStore || legacyGlobalUIStore).state.states.activeDebugger !== true
+    ) {
+      provideRtkDesignSystem(document.documentElement, config.designTokens);
     }
   }
 

--- a/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
+++ b/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
@@ -84,11 +84,11 @@ export class RtkUiProvider {
     // Listen for store requests from child components
     this.setupStoreRequestListener();
 
-    this.onMeetingChange(this.meeting);
-    this.onIconPackChange(this.iconPack);
-    this.onTChange(this.t);
-    this.onConfigChange(this.config);
-    this.onSizeChange(this.size);
+    this.meetingChanged(this.meeting);
+    this.iconPackChanged(this.iconPack);
+    this.tChanged(this.t);
+    this.configChanged(this.config);
+    this.sizeChanged(this.size);
 
     this.resizeObserver = new ResizeObserver(() => this.handleResize());
     this.resizeObserver.observe(this.host);
@@ -173,7 +173,7 @@ export class RtkUiProvider {
   }
 
   @Watch('meeting')
-  onMeetingChange(meeting: Meeting) {
+  meetingChanged(meeting: Meeting) {
     if (meeting) {
       this.peerStore = createPeerStore({
         meeting,
@@ -228,21 +228,21 @@ export class RtkUiProvider {
   }
 
   @Watch('iconPack')
-  onIconPackChange(newIconPack: IconPack) {
+  iconPackChanged(newIconPack: IconPack) {
     if (this.peerStore) {
       this.peerStore.state.iconPack = newIconPack;
     }
   }
 
   @Watch('t')
-  onTChange(newT: RtkI18n) {
+  tChanged(newT: RtkI18n) {
     if (this.peerStore) {
       this.peerStore.state.t = newT;
     }
   }
 
   @Watch('config')
-  onConfigChange(config: UIConfig) {
+  configChanged(config: UIConfig) {
     if (this.peerStore) {
       this.peerStore.state.config = config;
     }
@@ -257,7 +257,7 @@ export class RtkUiProvider {
   }
 
   @Watch('size')
-  onSizeChange(newSize: Size) {
+  sizeChanged(newSize: Size) {
     if (this.peerStore) {
       this.peerStore.state.size = newSize;
     }

--- a/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
+++ b/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
@@ -5,7 +5,6 @@ import {
   createDefaultConfig,
   RtkI18n,
   IconPack,
-  Size,
   States,
   UIConfig,
   useLanguage,
@@ -19,7 +18,6 @@ import {
 } from '../../utils/sync-with-store/ui-store';
 import deepMerge from 'lodash-es/merge';
 import { PermissionSettings } from '../../types/props';
-import { getSize } from '../../utils/size';
 
 const LEAVE_ROOM_TIMER = 10000;
 
@@ -55,9 +53,6 @@ export class RtkUiProvider {
   /** Fill type */
   @Prop({ reflect: true }) mode: MeetingMode = 'fixed';
 
-  /** Size */
-  @Prop({ reflect: true, mutable: true }) size: Size;
-
   /** Whether to show setup screen or not */
   @Prop() showSetupScreen: boolean = false;
 
@@ -68,8 +63,6 @@ export class RtkUiProvider {
   @Event({ eventName: 'rtkStatesUpdate' }) statesUpdate: EventEmitter<States>;
 
   private authErrorListener: (ev: CustomEvent<Error>) => void;
-
-  private resizeObserver: ResizeObserver;
 
   connectedCallback() {
     if (typeof window !== 'undefined') {
@@ -88,14 +81,9 @@ export class RtkUiProvider {
     this.iconPackChanged(this.iconPack);
     this.tChanged(this.t);
     this.configChanged(this.config);
-    this.sizeChanged(this.size);
-
-    this.resizeObserver = new ResizeObserver(() => this.handleResize());
-    this.resizeObserver.observe(this.host);
   }
 
   disconnectedCallback() {
-    this.resizeObserver.disconnect();
     window.removeEventListener('rtkError', this.authErrorListener);
 
     // Remove event listeners
@@ -180,7 +168,6 @@ export class RtkUiProvider {
         config: this.config,
         iconPack: this.iconPack,
         t: this.t,
-        size: this.size,
         providerId: this.providerId,
       }) as RtkUiStoreExtended;
 
@@ -255,17 +242,6 @@ export class RtkUiProvider {
       provideRtkDesignSystem(document.documentElement, config.designTokens);
     }
   }
-
-  @Watch('size')
-  sizeChanged(newSize: Size) {
-    if (this.peerStore) {
-      this.peerStore.state.size = newSize;
-    }
-  }
-
-  private handleResize = () => {
-    this.size = getSize(this.host.clientWidth);
-  };
 
   private roomJoinedListener = () => {
     this.updateStates({ meeting: 'joined' });

--- a/packages/core/src/components/rtk-waiting-screen/rtk-waiting-screen.tsx
+++ b/packages/core/src/components/rtk-waiting-screen/rtk-waiting-screen.tsx
@@ -2,7 +2,7 @@ import { Component, Host, h, Prop } from '@stencil/core';
 import { UIConfig } from '../../types/ui-config';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { IconPack, defaultIconPack } from '../../lib/icons';
-import { defaultConfig } from '../../exports';
+import { createDefaultConfig } from '../../exports';
 import { SyncWithStore } from '../../utils/sync-with-store';
 import { Meeting } from '../../types/rtk-client';
 
@@ -18,7 +18,9 @@ export class RtkWaitingScreen {
   meeting: Meeting;
 
   /** Config */
-  @Prop() config: UIConfig = defaultConfig;
+  @SyncWithStore()
+  @Prop()
+  config: UIConfig = createDefaultConfig();
 
   /** Icon pack */
   @SyncWithStore()

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -5,7 +5,7 @@ export { provideRtkDesignSystem } from './utils/provide-design-system';
 export { extendConfig, generateConfig } from './utils/config';
 export { sendNotification } from './utils/notification';
 export { RtkUiBuilder } from './lib/builder';
-export { uiStore, getInitialStates } from './utils/sync-with-store/ui-store';
+export { uiStore, uiState, getInitialStates, createPeerStore } from './utils/sync-with-store/ui-store';
 
 // addons
 export { registerAddons, Addon } from './lib/addons';
@@ -23,7 +23,7 @@ export {
 export { Peer } from './types/rtk-client';
 
 // UIConfig, Icon Pack, i18n and Notification Sounds
-export { defaultConfig } from './lib/default-ui-config';
+export { defaultConfig, createDefaultConfig } from './lib/default-ui-config';
 export { IconPack, defaultIconPack } from './lib/icons';
 export { LangDict, defaultLanguage, RtkI18n, useLanguage } from './lib/lang';
 export { Sound, default as RtkNotificationsAudio } from './lib/notification';

--- a/packages/core/src/lib/builder/index.ts
+++ b/packages/core/src/lib/builder/index.ts
@@ -1,6 +1,6 @@
 import { UIConfig } from '../../exports';
 import { UIRoot, Element as E, StyleProps } from '../../types/ui-config/root';
-import { defaultConfig } from '../default-ui-config';
+import { createDefaultConfig } from '../default-ui-config';
 
 type UIElem = UIRoot['string'];
 type FullUIElem = Exclude<UIElem, E[]>;
@@ -138,7 +138,7 @@ export class RtkUiBuilder {
   private config: UIConfig;
 
   constructor(config?: UIConfig) {
-    this.config = config || defaultConfig;
+    this.config = config || createDefaultConfig();
   }
 
   /**

--- a/packages/core/src/lib/default-ui-config.ts
+++ b/packages/core/src/lib/default-ui-config.ts
@@ -1,4 +1,5 @@
 import { UIConfig } from '../types/ui-config';
+import clone from '../utils/clone';
 
 /**
  * The default UI Config
@@ -348,4 +349,8 @@ export const defaultConfig: UIConfig = {
     participant_chat_message_sound_notification_limit: 10,
     videoFit: 'cover',
   },
+};
+
+export const createDefaultConfig = (): UIConfig => {
+  return clone(defaultConfig);
 };

--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -1,5 +1,5 @@
 import type { RTKThemePreset, RTKPermissionsPreset } from '@cloudflare/realtimekit';
-import { defaultConfig } from '../lib/default-ui-config';
+import { createDefaultConfig } from '../lib/default-ui-config';
 import { UIConfig } from '../types/ui-config';
 import { DesignTokens } from '../types/ui-config/design-tokens';
 import { isValidHexColor } from './color';
@@ -12,7 +12,7 @@ import { isLiveStreamHost } from './livestream';
  * @param config Your extended UI Config
  * @returns New extended UI Config object
  */
-export const extendConfig = (config: UIConfig, baseConfig: UIConfig = defaultConfig) => {
+export const extendConfig = (config: UIConfig, baseConfig: UIConfig = createDefaultConfig()) => {
   let newConfig = Object.assign({}, baseConfig);
 
   deepMerge(newConfig, config);

--- a/packages/core/src/utils/sync-with-store/index.ts
+++ b/packages/core/src/utils/sync-with-store/index.ts
@@ -38,7 +38,15 @@ export function SyncWithStore() {
           
           // Blindly put peer specific store's value for propName in host propName
           const storeValue = event.detail.store.state[propName];
-          host[propName as string] = storeValue;
+          host.componentOnReady().then(() => {
+            /**
+             * NOTE(ravindra-dyte):
+             * https://stenciljs.com/docs/api#componentonready
+             * This psudo ready callback is to ensure that the component is ready to accept props
+             * Without this, changing the prop would not trigger @Watch of prop in the initial mount phase
+             *  */
+            host[propName as string] = storeValue;
+          });
           appendElement(propName, host, event.detail.store);
           host[`_rtkStoreToCleanup-${propName}`] = event.detail.store;
           // Since peer specific store is available, remove element prop from global store

--- a/packages/core/src/utils/sync-with-store/index.ts
+++ b/packages/core/src/utils/sync-with-store/index.ts
@@ -1,25 +1,111 @@
 import { getElement, ComponentInterface } from '@stencil/core';
-import { uiStore as store, appendElement, removeElement, type RtkUiStore } from './ui-store';
+import {
+  uiStore as legacyGlobalUIStore,
+  appendElement,
+  removeElement,
+  type RtkUiStore,
+  type RtkUiStoreExtended,
+} from './ui-store';
 
 export function SyncWithStore() {
+
   return function (proto: ComponentInterface, propName: keyof RtkUiStore) {
     const { connectedCallback, disconnectedCallback } = proto;
 
     proto.connectedCallback = function () {
       const host = getElement(this);
       const value = host[propName as string];
+      host[`_rtkStoreToCleanup-${propName}`] = legacyGlobalUIStore;
 
+      /**
+       * NOTE(ravindra-dyte):
+       * For backward compatibility, let's use global store.
+       * If rtk-ui-provider in parent hierarchy is available, we will use peer specific store.
+       * If provider is found, All states will be solely controlled by RtkUiProvider.
+       */
       if (!value) {
-        const storeValue = store.state[propName];
+        const storeValue = legacyGlobalUIStore.state[propName];
         host[propName as string] = storeValue;
-        appendElement(propName, host);
+        appendElement(propName, host, legacyGlobalUIStore as RtkUiStoreExtended);
       }
+
+      // Listen for provider response
+      const storeResponseListener = (
+        event: CustomEvent<{ store: RtkUiStoreExtended; requestId: string }>
+      ) => {
+        const requestId = (host as any)._storeRequestId;
+        if (event.detail.requestId === requestId) {
+          
+          // Blindly put peer specific store's value for propName in host propName
+          const storeValue = event.detail.store.state[propName];
+          host[propName as string] = storeValue;
+          appendElement(propName, host, event.detail.store);
+          host[`_rtkStoreToCleanup-${propName}`] = event.detail.store;
+          // Since peer specific store is available, remove element prop from global store
+          removeElement(propName, host, legacyGlobalUIStore as RtkUiStoreExtended)
+
+          document.removeEventListener('rtkProvideStore', storeResponseListener);
+        }
+      };
+
+      // Store listener reference for cleanup
+      host[`_rtkStoreResponseListener-${propName}`] = storeResponseListener;
+      document.addEventListener('rtkProvideStore', storeResponseListener);
+
+      // Generate unique request ID
+      const requestId = `${host.tagName}-${Date.now()}-${Math.random()}`;
+      (host as any)._storeRequestId = requestId;
+
+      // Request store from provider
+
+      const requestEvent = new CustomEvent('rtkRequestStore', {
+        detail: { element: host, propName, requestId },
+        bubbles: true,
+        composed: true, // Allow event to cross shadow DOM boundaries
+      });
+
+      host.dispatchEvent(requestEvent);
+      
+      // Listen for peer specific store ready event to use the correct store
+      const storeReadyListener = () => {
+        // Re-request store (peer specific store should now be available)
+        const newRequestId = `${host.tagName}-${Date.now()}-${Math.random().toString(36)}`;
+        (host as any)._storeRequestId = newRequestId;
+        const retryRequestEvent = new CustomEvent('rtkRequestStore', {
+          detail: { element: host, propName, requestId: newRequestId },
+          bubbles: true,
+          composed: true,
+        });
+        
+        host.dispatchEvent(retryRequestEvent);
+        document.removeEventListener('rtkPeerStoreReady', storeReadyListener);
+      };
+
+      // Store listener reference for cleanup
+      host[`_rtkStoreReadyListener-${propName}`] = storeReadyListener;
+      document.addEventListener('rtkPeerStoreReady', storeReadyListener);
 
       return connectedCallback?.call(this);
     };
 
     proto.disconnectedCallback = function () {
-      removeElement(propName, getElement(this));
+      const host = getElement(this);
+
+      removeElement(propName, host, host[`_rtkStoreToCleanup-${propName}`] as RtkUiStoreExtended);
+
+      // Clean up event listeners to prevent memory leaks
+      const storeResponseListener = host[`_rtkStoreResponseListener-${propName}`];
+      if (storeResponseListener) {
+        document.removeEventListener('rtkProvideStore', storeResponseListener);
+        delete host[`_rtkStoreResponseListener-${propName}`];
+      }
+
+      const storeReadyListener = host[`_rtkStoreReadyListener-${propName}`];
+      if (storeReadyListener) {
+        document.removeEventListener('rtkPeerStoreReady', storeReadyListener);
+        delete host[`_rtkStoreReadyListener-${propName}`];
+      }
+
       return disconnectedCallback?.call(this);
     };
   };

--- a/packages/core/src/utils/sync-with-store/ui-store.ts
+++ b/packages/core/src/utils/sync-with-store/ui-store.ts
@@ -1,36 +1,51 @@
-import { createStore } from '@stencil/store';
-import { Meeting } from '../../types/rtk-client';
+import { createStore, ObservableMap } from '@stencil/store';
+import { Meeting, RealtimeKitClient } from '../../types/rtk-client';
 import { useLanguage, type RtkI18n } from '../../lib/lang';
 import { defaultIconPack, type IconPack } from '../../lib/icons';
 import { type States } from '../../types/props';
 import { getUserPreferences } from '../user-prefs';
-import { defaultConfig, UIConfig } from '../../exports';
+import { createDefaultConfig, UIConfig } from '../../exports';
 import { Size } from '../../exports';
 
-export const getInitialStates = (): States => ({
+export const getInitialStates = (peerId?: string): States => ({
   meeting: 'idle',
   prefs: getUserPreferences(),
+  peerId: peerId || 'LEGACY_GLOBAL_PEER',
 });
 
 export interface RtkUiStore {
-  meeting: Meeting | undefined;
+  meeting: Meeting | undefined | null;
   t: RtkI18n;
   iconPack: IconPack;
   states: States;
   config: UIConfig;
   size: Size | undefined;
+  peerId: string | null;
+  storeType: 'global' | 'peer';
+  storeId: string;
 }
 
+// Extended type for stores that have elementsMap attached
+export type RtkUiStoreExtended = ObservableMap<RtkUiStore> & {
+  elementsMap: Map<string, HTMLElement[]>;
+};
+
 const uiStore = createStore<RtkUiStore>({
-  meeting: undefined,
+  meeting: null,
   t: useLanguage(),
   iconPack: defaultIconPack,
   states: getInitialStates(),
-  config: defaultConfig,
+  config: createDefaultConfig(),
   size: undefined,
-});
+  peerId: 'global',
+  storeType: 'global',
+  storeId: 'store-global',
+}) as RtkUiStoreExtended;
 
 const elementsMap = new Map<string, any[]>();
+
+// Attach elementsMap to global store for consistency
+(uiStore as any).elementsMap = elementsMap;
 
 uiStore.use({
   set: (propName, newValue, oldValue) => {
@@ -52,26 +67,115 @@ uiStore.use({
   },
 });
 
-function appendElement(propName: string, element: any) {
-  const elements = elementsMap.get(propName);
-  if (!elements) {
-    elementsMap.set(propName, [element]);
-  } else {
-    elements.push(element);
-  }
+const uiState = uiStore.state;
+
+export { uiStore, uiState };
+
+// Function to create a new store instance for peer-specific stores
+export function createPeerStore({
+  meeting,
+  config,
+  providerId,
+  iconPack,
+  t,
+  size
+}: {
+  meeting: RealtimeKitClient;
+  config?: UIConfig;
+  providerId: string;
+  iconPack: IconPack;
+  t: RtkI18n;
+  size: Size | undefined;
+}): RtkUiStoreExtended {
+  const store = createStore<RtkUiStore>({
+    meeting: meeting,
+    t,
+    iconPack,
+    states: getInitialStates(meeting.self.peerId),
+    config: config || createDefaultConfig(),
+    size,
+    peerId: meeting.self.id,
+    storeType: 'peer',
+    // Use provider id's numeric portion as store id for easier debugging
+    storeId: 'store-' + providerId.replace('provider-', ''),
+  });
+
+  const peerElementsMap = new Map<string, any[]>();
+
+  // Attach elementsMap to store so appendElement/removeElement can access it
+  (store as RtkUiStoreExtended).elementsMap = peerElementsMap;
+
+  store.use({
+    set: (propName, newValue, oldValue) => {
+      const elements = peerElementsMap.get(propName as string);
+      if (elements) {
+        peerElementsMap.set(
+          propName as string,
+          elements.filter((element) => {
+            const currentValue = element[propName];
+            if (currentValue === oldValue) {
+              element[propName] = newValue;
+              return true;
+            } else {
+              return false;
+            }
+          })
+        );
+      }
+    },
+  });
+
+  return store as RtkUiStoreExtended;
 }
 
-function removeElement(propName: string, element: any) {
-  const elements = elementsMap.get(propName);
-  if (elements && elements.length > 0) {
-    const index = elements.indexOf(element);
-    if (index !== -1) {
-      elements.splice(index, 1);
-      elementsMap.set(propName, elements);
+function appendElement(
+  propName: string,
+  element: HTMLElement,
+  targetStore: RtkUiStoreExtended = uiStore as RtkUiStoreExtended
+) {
+  const elementsMapToUse = targetStore.elementsMap;
+
+  if (!elementsMapToUse) {
+    console.error(`appendElement: No elementsMap found on store`, targetStore);
+    return;
+  }
+
+  const elements = elementsMapToUse.get(propName);
+
+  if (!elements) {
+    try {
+      elementsMapToUse.set(propName, [element]);
+    } catch (error) {
+      console.error(`appendElement: Error setting new array:`, error);
+    }
+  } else {
+    try {
+      elements.push(element);
+    } catch (error) {
+      console.error(`appendElement: Error adding element:`, error);
     }
   }
 }
 
-const uiState = uiStore.state;
+function removeElement(
+  propName: string,
+  element: HTMLElement,
+  targetStore: RtkUiStoreExtended = uiStore as RtkUiStoreExtended
+) {
+  const elementsMapToUse = targetStore.elementsMap;
 
-export { uiStore, uiState, appendElement, removeElement };
+  if (!elementsMapToUse) {
+    console.error(`removeElement: No elementsMap found on store`, targetStore);
+    return;
+  }
+
+  const elements = elementsMapToUse.get(propName);
+  if (elements) {
+    const index = elements.indexOf(element);
+    if (index > -1) {
+      elements.splice(index, 1);
+    }
+  }
+}
+
+export { appendElement, removeElement };

--- a/packages/core/src/utils/sync-with-store/ui-store.ts
+++ b/packages/core/src/utils/sync-with-store/ui-store.ts
@@ -48,14 +48,14 @@ const elementsMap = new Map<string, any[]>();
 (uiStore as any).elementsMap = elementsMap;
 
 uiStore.use({
-  set: (propName, newValue, oldValue) => {
+  set: (propName, newValue) => {
     const elements = elementsMap.get(propName as string);
     if (elements) {
       elementsMap.set(
         propName as string,
         elements.filter((element) => {
           const currentValue = element[propName];
-          if (currentValue === oldValue) {
+          if (currentValue !== newValue) {
             element[propName] = newValue;
             return true;
           } else {
@@ -106,14 +106,14 @@ export function createPeerStore({
   (store as RtkUiStoreExtended).elementsMap = peerElementsMap;
 
   store.use({
-    set: (propName, newValue, oldValue) => {
+    set: (propName, newValue) => {
       const elements = peerElementsMap.get(propName as string);
       if (elements) {
         peerElementsMap.set(
           propName as string,
           elements.filter((element) => {
             const currentValue = element[propName];
-            if (currentValue === oldValue) {
+            if (currentValue !== newValue) {
               element[propName] = newValue;
               return true;
             } else {

--- a/packages/core/src/utils/sync-with-store/ui-store.ts
+++ b/packages/core/src/utils/sync-with-store/ui-store.ts
@@ -5,7 +5,6 @@ import { defaultIconPack, type IconPack } from '../../lib/icons';
 import { type States } from '../../types/props';
 import { getUserPreferences } from '../user-prefs';
 import { createDefaultConfig, UIConfig } from '../../exports';
-import { Size } from '../../exports';
 
 export const getInitialStates = (peerId?: string): States => ({
   meeting: 'idle',
@@ -19,7 +18,6 @@ export interface RtkUiStore {
   iconPack: IconPack;
   states: States;
   config: UIConfig;
-  size: Size | undefined;
   peerId: string | null;
   storeType: 'global' | 'peer';
   storeId: string;
@@ -36,7 +34,6 @@ const uiStore = createStore<RtkUiStore>({
   iconPack: defaultIconPack,
   states: getInitialStates(),
   config: createDefaultConfig(),
-  size: undefined,
   peerId: 'global',
   storeType: 'global',
   storeId: 'store-global',
@@ -77,15 +74,13 @@ export function createPeerStore({
   config,
   providerId,
   iconPack,
-  t,
-  size
+  t
 }: {
   meeting: RealtimeKitClient;
   config?: UIConfig;
   providerId: string;
   iconPack: IconPack;
   t: RtkI18n;
-  size: Size | undefined;
 }): RtkUiStoreExtended {
   const store = createStore<RtkUiStore>({
     meeting: meeting,
@@ -93,7 +88,6 @@ export function createPeerStore({
     iconPack,
     states: getInitialStates(meeting.self.peerId),
     config: config || createDefaultConfig(),
-    size,
     peerId: meeting.self.id,
     storeType: 'peer',
     // Use provider id's numeric portion as store id for easier debugging

--- a/packages/react-library/package.json
+++ b/packages/react-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/realtimekit-react-ui",
-  "version": "1.0.4-staging.2",
+  "version": "1.0.4-staging.3",
   "description": "Pre-built, ready-to-use React components, hooks and utilities for integrating with Cloudflare RealtimeKit",
   "repository": {
     "type": "git",

--- a/packages/react-library/package.json
+++ b/packages/react-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/realtimekit-react-ui",
-  "version": "1.0.4-staging.4",
+  "version": "1.0.4-staging.5",
   "description": "Pre-built, ready-to-use React components, hooks and utilities for integrating with Cloudflare RealtimeKit",
   "repository": {
     "type": "git",

--- a/packages/react-library/package.json
+++ b/packages/react-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/realtimekit-react-ui",
-  "version": "1.0.4-staging.1",
+  "version": "1.0.4-staging.2",
   "description": "Pre-built, ready-to-use React components, hooks and utilities for integrating with Cloudflare RealtimeKit",
   "repository": {
     "type": "git",

--- a/packages/react-library/package.json
+++ b/packages/react-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/realtimekit-react-ui",
-  "version": "1.0.3",
+  "version": "1.0.4-staging.1",
   "description": "Pre-built, ready-to-use React components, hooks and utilities for integrating with Cloudflare RealtimeKit",
   "repository": {
     "type": "git",

--- a/packages/react-library/package.json
+++ b/packages/react-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/realtimekit-react-ui",
-  "version": "1.0.4-staging.3",
+  "version": "1.0.4-staging.4",
   "description": "Pre-built, ready-to-use React components, hooks and utilities for integrating with Cloudflare RealtimeKit",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description
1. Removed all singletons from UI KIt. UI Kit now supports multi meeting support. Samples can be found at https://github.com/dyte-io/react-samples/tree/main/samples
2. Added Peer Store Sync to make integration easier for custom implementation.
This helps in achieve the following:
```
// Before
<rtk-grid meeting={meeting} config={config} t={t} iconPack={iconPack}>
<rtk-controlbar meeting={meeting} config={config} t={t} iconPack={iconPack}>

// Now
<rtk-ui-provider meeting={meeting} config={config} t={t} iconPack={iconPack}>
       <rtk-grid /> // No need to pass every prop again
       <rtk-controlbar /> // No need to pass every prop again
</rtk-ui-provider>
```