### PR TITLE
fix(safari-dialog): modals & setting were not showing up

### DIFF
--- a/packages/core/src/components/rtk-dialog/rtk-dialog.css
+++ b/packages/core/src/components/rtk-dialog/rtk-dialog.css
@@ -27,4 +27,6 @@
    * Make sure to test with Safari.
    */
   @apply max-w-full;
+  height: auto;
+  min-height: fit-content;
 }

--- a/packages/core/src/components/rtk-dialog/rtk-dialog.css
+++ b/packages/core/src/components/rtk-dialog/rtk-dialog.css
@@ -21,7 +21,8 @@
 
 ::slotted(*) {
   /*
-   * Safari's max-h-full calculation under native dialog component is faulty (div works).
+   * In Safari, 
+   * Adding max-h-full might break settings, audio_playback and troubleshooting modals.
    * If you ever have to add max-h-full back,
    * Make sure to test with Safari.
    */

--- a/packages/core/src/components/rtk-dialog/rtk-dialog.css
+++ b/packages/core/src/components/rtk-dialog/rtk-dialog.css
@@ -20,5 +20,10 @@
 }
 
 ::slotted(*) {
-  @apply max-h-full max-w-full;
+  /*
+   * Safari's max-h-full calculation under native dialog component is faulty (div works).
+   * If you ever have to add max-h-full back,
+   * Make sure to test with Safari.
+   */
+  @apply max-w-full;
 }


### PR DESCRIPTION
### Description

Why it broke suddenly?
https://github.com/dyte-io/realtimekit-ui/commit/a02e54edbe648c1105e94d1a89add09c705b3b51 shifted div to dialog, dialog for safari has issues with max-h-full. It is not able to calculate it properly for slotted elements in a native dialog component, causing height to become zero thus not showing anything.

### Screenshots

Before fix
On click of rtk-settings-toggle.
<img width="1326" height="672" alt="image" src="https://github.com/user-attachments/assets/8c1188d7-21d0-4cda-b252-0f050f1e644c" />

After fix
On click of rtk-settings-toggle
<img width="1322" height="675" alt="image" src="https://github.com/user-attachments/assets/1ef4665f-f1dc-4126-9f64-2a142cbb2163" />
