### PR TITLE
fix(safari-dialog): breakout rooms manager was not visible in safari

### DIFF
--- a/packages/core/src/components/rtk-breakout-rooms-manager/rtk-breakout-rooms-manager.css
+++ b/packages/core/src/components/rtk-breakout-rooms-manager/rtk-breakout-rooms-manager.css
@@ -62,7 +62,7 @@ label {
 
 .participant-config-wrapper {
   width: 850px;
-  height: 595px;
+  min-height: 595px;
   max-width: 100%;
   max-height: 100%;
   @apply bg-background-900 rounded-md;


### PR DESCRIPTION
### Description

Breakout rooms manager was not visible in Safari

### After Fixes
<img width="1307" height="784" alt="image" src="https://github.com/user-attachments/assets/89044e0b-0be2-409c-8a0d-e5e700d308dc" />

