### PR TITLE
fix(component): add size prop to the component to prevent type errors

### DIFF
--- a/packages/core/src/components/rtk-clock/rtk-clock.tsx
+++ b/packages/core/src/components/rtk-clock/rtk-clock.tsx
@@ -2,6 +2,7 @@ import { Component, Host, h, Prop, Watch, State } from '@stencil/core';
 import { defaultIconPack, IconPack } from '../../lib/icons';
 import { SyncWithStore } from '../../utils/sync-with-store';
 import { Meeting } from '../../types/rtk-client';
+import { Size } from '../../types/props';
 
 const addZero = (n: number) => Math.trunc(n).toString().padStart(2, '0');
 
@@ -26,6 +27,9 @@ export class RtkClock {
   @SyncWithStore()
   @Prop()
   iconPack: IconPack = defaultIconPack;
+
+  /** Size */
+  @Prop({ reflect: true }) size: Size;
 
   @State() startedTime: string;
   @State() timeDiff: number;


### PR DESCRIPTION
the rtk-clock component is missing the size property so there's an error type when using the prop because it's missing in the type definition. the styles are defined and properly applied though.

fix #48

### Description

Add the prop to the component

### Screenshots

<!-- Add screenshots if applicable -->
