### PR TITLE
fix(store-inconsistency): for back to back meetings, 2nd meeting onwards, dialogs were not shown

### DIFF
--- a/packages/core/src/utils/sync-with-store/index.ts
+++ b/packages/core/src/utils/sync-with-store/index.ts
@@ -51,8 +51,6 @@ export function SyncWithStore() {
           host[`_rtkStoreToCleanup-${propName}`] = event.detail.store;
           // Since peer specific store is available, remove element prop from global store
           removeElement(propName, host, legacyGlobalUIStore as RtkUiStoreExtended)
-
-          document.removeEventListener('rtkProvideStore', storeResponseListener);
         }
       };
 
@@ -86,7 +84,6 @@ export function SyncWithStore() {
         });
         
         host.dispatchEvent(retryRequestEvent);
-        document.removeEventListener('rtkPeerStoreReady', storeReadyListener);
       };
 
       // Store listener reference for cleanup

--- a/packages/core/src/utils/sync-with-store/ui-store.ts
+++ b/packages/core/src/utils/sync-with-store/ui-store.ts
@@ -144,6 +144,13 @@ function appendElement(
     }
   } else {
     try {
+      /**
+       * NOTE(ravindra-dyte):
+       * If the element+propName exists already, remove it first
+       * This could happen in https://github.com/dyte-io/react-samples/tree/main/samples/back-to-back-meetings,
+       * where the same component is re-rendered multiple times under different providers
+       *  */
+      removeElement(propName, element, targetStore);
       elements.push(element);
     } catch (error) {
       console.error(`appendElement: Error adding element:`, error);


### PR DESCRIPTION
### Description
In SyncWithStore, Assumption was that the client integrations would have a different RtkUIProvider when they need a second meeting, however in some client cases, such as https://github.com/dyte-io/react-samples/tree/main/samples/back-to-back-meetings, having back to back meetings using same RtkUIProvider instance causes few components (especially RtkDialogManager) to not use the latest store, meeting & states, second meeting onwards.

This PR ensures that unless the components are actually disconnected, their store listeners will not be removed. This would help components keep on latching to latest stores and showing dialogs properly.