### PR TITLE
fix(rtk-polls): under rtk-ui-provider, polls were not reattaching due to internal error

### DIFF
--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -996,6 +996,10 @@ export namespace Components {
           * Meeting object
          */
         "meeting": Meeting;
+        /**
+          * Size
+         */
+        "size": Size;
     }
     /**
      * A confirmation modal.
@@ -7650,6 +7654,10 @@ declare namespace LocalJSX {
           * Meeting object
          */
         "meeting"?: Meeting;
+        /**
+          * Size
+         */
+        "size"?: Size;
     }
     /**
      * A confirmation modal.

--- a/packages/core/src/components/rtk-caption-toggle/rtk-caption-toggle.tsx
+++ b/packages/core/src/components/rtk-caption-toggle/rtk-caption-toggle.tsx
@@ -61,7 +61,7 @@ export class RtkCaptionToggle {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting === null) return;
+    if (!meeting) return;
     this.permissionsUpdateListener();
 
     this.meeting.self.permissions.addListener('permissionsUpdate', this.permissionsUpdateListener);

--- a/packages/core/src/components/rtk-dialog-manager/rtk-dialog-manager.tsx
+++ b/packages/core/src/components/rtk-dialog-manager/rtk-dialog-manager.tsx
@@ -66,7 +66,7 @@ export class RtkDialogManager {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting == undefined) return;
+    if (!meeting) return;
     const { stage } = meeting;
     stage?.addListener('stageStatusUpdate', this.stageStatusUpdateListener);
   }

--- a/packages/core/src/components/rtk-participant-tile/rtk-participant-tile.tsx
+++ b/packages/core/src/components/rtk-participant-tile/rtk-participant-tile.tsx
@@ -106,15 +106,15 @@ export class RtkParticipantTile {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting == undefined) return;
+    if (!meeting) return;
     this.participantsChanged(this.participant);
   }
 
   @Watch('participant')
   participantsChanged(participant: Peer) {
-    if (participant == undefined) return;
+    if (!participant) return;
 
-    if (this.meeting === undefined) {
+    if (!this.meeting) {
       if (this.isPreview) {
         this.videoEl && this.participant.registerVideoElement(this.videoEl, this.isPreview);
       }

--- a/packages/core/src/components/rtk-plugin-main/rtk-plugin-main.tsx
+++ b/packages/core/src/components/rtk-plugin-main/rtk-plugin-main.tsx
@@ -52,7 +52,7 @@ export class RtkPluginMain {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting == undefined) return;
+    if (!meeting) return;
     const enabled = this.canInteractWithPlugin();
     this.viewModeEnabled = !enabled;
     writeTask(() => {

--- a/packages/core/src/components/rtk-polls/rtk-polls.tsx
+++ b/packages/core/src/components/rtk-polls/rtk-polls.tsx
@@ -50,7 +50,7 @@ export class RtkPolls {
   @State() create: boolean = false;
 
   /** Polls */
-  @State() polls: Poll[];
+  @State() polls: Poll[] = [];
 
   @State() permissions: RTKPermissionsPreset;
 
@@ -66,9 +66,9 @@ export class RtkPolls {
 
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
-    if (meeting == undefined) return;
+    if (!meeting) return;
 
-    if (meeting && !meeting.polls) return;
+    if (!meeting.polls) return;
 
     this.permissions = this.meeting.self.permissions;
     this.polls = [...meeting.polls.items];
@@ -133,7 +133,7 @@ export class RtkPolls {
               />
             )}
           </div>
-          {this.permissions.polls.canCreate && (
+          {this.permissions?.polls?.canCreate && (
             <rtk-button
               kind="wide"
               onClick={() => this.toggleCreateState()}


### PR DESCRIPTION
### Description

Fixed internal errors in rtk-polls when it is rendered without meeting, participant, or permissions props — a scenario common in HTML samples.

Refactored meeting null checks to prevent similar errors in other components during initial renders without props.

A separate PR will address missing-prop issues for lower-level components.