### PR TITLE
fix(toggle-border-highlight): remove border from polls, chats etc toggles, once sidebar is closed

### DIFF
--- a/packages/core/src/components/rtk-sidebar-ui/rtk-sidebar-ui.tsx
+++ b/packages/core/src/components/rtk-sidebar-ui/rtk-sidebar-ui.tsx
@@ -49,6 +49,18 @@ export class RtkSidebarUi {
 
   private onClose = () => {
     this.sidebarClose.emit();
+    /**
+     * NOTE(ravindra-cloudflare):
+     * If the sidebar was opened from a RealtimeKit component, apply a blur (remove focus/active class).
+     * This helps remove the active border from RTK toggles, such as rtk-polls-toggle, rtk-chat-toggle, etc.
+     */
+    if (
+      document.activeElement instanceof HTMLElement &&
+      document.activeElement.tagName?.includes('RTK-') &&
+      document.activeElement.blur instanceof Function
+    ) {
+      document.activeElement.blur();
+    }
   };
 
   private keydownListener: (e: KeyboardEvent) => void;


### PR DESCRIPTION
### Description

Removing toggle hightlights once sidebar is closed.

### Screenshots

Before

<img width="1352" height="745" alt="image" src="https://github.com/user-attachments/assets/dd812438-005a-4e71-9457-1b985033c89f" />

After
<img width="1352" height="745" alt="image" src="https://github.com/user-attachments/assets/3b7b36e2-f1c8-498a-9fca-afe29e2d3332" />
