### PR TITLE
fix(audio-visualiser): muted visualiser was shown as dot

### DIFF
--- a/packages/core/src/components/rtk-audio-visualizer/rtk-audio-visualizer.css
+++ b/packages/core/src/components/rtk-audio-visualizer/rtk-audio-visualizer.css
@@ -4,6 +4,10 @@
   @apply block w-fit;
 }
 
+.audioActivePadding {
+  @apply p-1;
+}
+
 canvas,
 rtk-icon {
   @apply h-6 w-6;

--- a/packages/core/src/components/rtk-audio-visualizer/rtk-audio-visualizer.css
+++ b/packages/core/src/components/rtk-audio-visualizer/rtk-audio-visualizer.css
@@ -4,10 +4,6 @@
   @apply block w-fit;
 }
 
-.hideMuted {
-  @apply p-1;
-}
-
 canvas,
 rtk-icon {
   @apply h-6 w-6;

--- a/packages/core/src/components/rtk-audio-visualizer/rtk-audio-visualizer.tsx
+++ b/packages/core/src/components/rtk-audio-visualizer/rtk-audio-visualizer.tsx
@@ -48,7 +48,7 @@ export class RtkAudioVisualizer {
   @Prop()
   t: RtkI18n = useLanguage();
 
-  /** Hide when there is no audio / audio is muted */
+  /** Hide the visualizer if audio is muted */
   @Prop() hideMuted: boolean = false;
 
   /** Audio visualizer for screensharing, it will use screenShareTracks.audio instead of audioTrack */
@@ -158,7 +158,11 @@ export class RtkAudioVisualizer {
 
     return (
       <Host>
-        <div>
+        <div
+          class={{
+            audioActivePadding: this.hideMuted && this.audioEnabled,
+          }}
+        >
           <canvas
             width="24"
             height="24"

--- a/packages/core/src/components/rtk-audio-visualizer/rtk-audio-visualizer.tsx
+++ b/packages/core/src/components/rtk-audio-visualizer/rtk-audio-visualizer.tsx
@@ -154,13 +154,11 @@ export class RtkAudioVisualizer {
   }
 
   render() {
+    if (this.hideMuted && !this.audioEnabled) return null;
+
     return (
       <Host>
-        <div
-          class={{
-            hideMuted: this.hideMuted,
-          }}
-        >
+        <div>
           <canvas
             width="24"
             height="24"
@@ -171,7 +169,7 @@ export class RtkAudioVisualizer {
             ref={(el) => (this.visualizer = el)}
             part="canvas"
           ></canvas>
-          {!this.isScreenShare && !this.audioEnabled && this.hideMuted !== true && (
+          {!this.isScreenShare && !this.audioEnabled && (
             <rtk-icon icon={this.iconPack.mic_off} part="mic-off-icon" />
           )}
         </div>


### PR DESCRIPTION
### Description
rtk-audio-visualiser was being shown as dot (rounded div) rather than ideally being hidden


### Screenshots

Before
<img width="590" height="440" alt="Screenshot 2025-10-01 at 12 05 26" src="https://github.com/user-attachments/assets/7f608320-a5af-4f8e-a2e0-1c4e7420963a" />

After
<img width="590" height="440" alt="image" src="https://github.com/user-attachments/assets/33f00f60-a0ff-4fea-b95e-af293cfb58fb" />

