### PR TITLE
fix(chat-notification-overflow): fixed overflow, clamped message to 2 lines with ellipsis

### DIFF
--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -222,7 +222,7 @@ export namespace Components {
      */
     interface RtkAudioVisualizer {
         /**
-          * Hide when there is no audio / audio is muted
+          * Hide the visualizer if audio is muted
          */
         "hideMuted": boolean;
         /**
@@ -6700,7 +6700,7 @@ declare namespace LocalJSX {
      */
     interface RtkAudioVisualizer {
         /**
-          * Hide when there is no audio / audio is muted
+          * Hide the visualizer if audio is muted
          */
         "hideMuted"?: boolean;
         /**

--- a/packages/core/src/components/rtk-notification/rtk-notification.css
+++ b/packages/core/src/components/rtk-notification/rtk-notification.css
@@ -28,7 +28,6 @@ img.loaded {
 
   p {
     @apply m-0 mr-1;
-    @apply inline-block;
   }
 
   blockquote {


### PR DESCRIPTION
### Description

Chat message notifications were overflowing the webkit box. In safari, it was working fine however Chromium-based browsers were not able to figure out lines to clamp due to the inside tag having display:inline-block. Chat notifications, or any text notification for that matter, does not require inline block.

### Screenshots

Before
<img width="682" height="522" alt="image" src="https://github.com/user-attachments/assets/ae182ee1-b40b-4423-aa5b-f008c221fb91" />


After
<img width="682" height="522" alt="image" src="https://github.com/user-attachments/assets/1aed4243-8c83-4485-8f96-9d916c80eac7" />

<img width="682" height="522" alt="image" src="https://github.com/user-attachments/assets/48926a2a-9428-4b3a-ba79-e67805dafa8a" />


