### PR TITLE
fix(audio-settings): aligned audio toggle similar to mirror my video, similar to initial SDK versions

### DIFF
--- a/packages/core/src/components/rtk-settings-audio/rtk-settings-audio.css
+++ b/packages/core/src/components/rtk-settings-audio/rtk-settings-audio.css
@@ -22,6 +22,10 @@ audio {
   }
 }
 
+.row {
+  @apply flex items-center justify-between gap-3;
+}
+
 rtk-audio-visualizer {
   @apply flex-shrink-0;
 }


### PR DESCRIPTION
### Description
Aligned Notification sound toggle, similar to "Mirror my video".  Ported the css from video component to audio components. All older SDK versions had this "mirro my video" design and spacing which seems to have broken in some version, sometime. It is similar to app.dyte.io now.


### Screenshots

Before:
<img width="869" height="532" alt="image" src="https://github.com/user-attachments/assets/1607b112-f20e-4c91-adee-4736917f8511" />
<img width="869" height="532" alt="image" src="https://github.com/user-attachments/assets/dd9fb1d4-eabb-4882-824e-de0cd4b9587e" />


After:
<img width="769" height="458" alt="image" src="https://github.com/user-attachments/assets/6c0b4447-e745-4037-8475-21fc6283df3e" />
<img width="749" height="486" alt="image" src="https://github.com/user-attachments/assets/8f5602e8-db2c-4508-b4f7-913af5f5f60a" />

app.dyte.io
<img width="915" height="575" alt="image" src="https://github.com/user-attachments/assets/7235147e-7a31-4f1c-9cdc-8373caff41c3" />


