### PR TITLE
fix(participant-tile): on setup screen preview, action buttons were rendered

### DIFF
--- a/packages/core/src/components/rtk-participant-tile/rtk-participant-tile.tsx
+++ b/packages/core/src/components/rtk-participant-tile/rtk-participant-tile.tsx
@@ -230,14 +230,14 @@ export class RtkParticipantTile {
         <slot>
           {!this.isPreview && (
             <Render
-            element="rtk-participant-tile"
-            defaults={defaults}
-            childProps={{
-              participant: this.participant,
-            }}
-            deepProps
-            onlyChildren
-          />
+              element="rtk-participant-tile"
+              defaults={defaults}
+              childProps={{
+                participant: this.participant,
+              }}
+              deepProps
+              onlyChildren
+            />
           )}
         </slot>
       </Host>

--- a/packages/core/src/components/rtk-participant-tile/rtk-participant-tile.tsx
+++ b/packages/core/src/components/rtk-participant-tile/rtk-participant-tile.tsx
@@ -228,7 +228,8 @@ export class RtkParticipantTile {
         )}
 
         <slot>
-          <Render
+          {!this.isPreview && (
+            <Render
             element="rtk-participant-tile"
             defaults={defaults}
             childProps={{
@@ -237,6 +238,7 @@ export class RtkParticipantTile {
             deepProps
             onlyChildren
           />
+          )}
         </slot>
       </Host>
     );


### PR DESCRIPTION
### Description

Action buttons were visible in the preview mode, click of which could lead to weird UI configuration states. Hiding the action buttons as they were never desired in preview mode, in first place.

Slot still exists for customisability.

### Screenshots

Before
<img width="771" height="578" alt="image" src="https://github.com/user-attachments/assets/5d72abd7-9ec5-41fd-8620-d568f20f11c1" />


After
<img width="741" height="493" alt="image" src="https://github.com/user-attachments/assets/14eda75a-e1ab-4d92-b40a-94dc4d7fba0a" />

