### PR TITLE
fix(chat): enabling paginated chat for "everyone" aka public chat

### DIFF
--- a/packages/core/src/components/rtk-breakout-room-manager/rtk-breakout-room-manager.tsx
+++ b/packages/core/src/components/rtk-breakout-room-manager/rtk-breakout-room-manager.tsx
@@ -267,12 +267,13 @@ export class RtkBreakoutRoomManager {
     if (!this.meeting || !this.room || !this.permissions) return null;
 
     /* NOTE(ravindra-cloudflare):
-    *  Checking if user can switch to this room
-    *  Check 1: if user has full access.
-    *  Check 2: For non-parent room, user has "switch meeting" access.
-    *  Check 3: For parent room, user has "switch to parent meeting" access.
-    */
-    const canSwitchToThisRoom = this.permissions.canAlterConnectedMeetings ||
+     *  Checking if user can switch to this room
+     *  Check 1: if user has full access.
+     *  Check 2: For non-parent room, user has "switch meeting" access.
+     *  Check 3: For parent room, user has "switch to parent meeting" access.
+     */
+    const canSwitchToThisRoom =
+      this.permissions.canAlterConnectedMeetings ||
       (this.permissions.canSwitchConnectedMeetings && !this.room.isParent) ||
       (this.permissions.canSwitchToParentMeeting && this.room.isParent);
 
@@ -352,22 +353,18 @@ export class RtkBreakoutRoomManager {
                     {this.t('breakout_rooms.assign')}
                   </rtk-button>
                 )}
-              {this.mode === 'edit' &&
-                !this.assigningParticipants &&
-                canSwitchToThisRoom && (
-                  <rtk-button
-                    kind="button"
-                    variant="ghost"
-                    class="assign-button"
-                    size="md"
-                    disabled={this.room.id === this.meeting.meta.meetingId}
-                    onClick={() => this.onJoin()}
-                  >
-                    {this.room.id === this.meeting.meta.meetingId
-                      ? this.t('joined')
-                      : this.t('join')}
-                  </rtk-button>
-                )}
+              {this.mode === 'edit' && !this.assigningParticipants && canSwitchToThisRoom && (
+                <rtk-button
+                  kind="button"
+                  variant="ghost"
+                  class="assign-button"
+                  size="md"
+                  disabled={this.room.id === this.meeting.meta.meetingId}
+                  onClick={() => this.onJoin()}
+                >
+                  {this.room.id === this.meeting.meta.meetingId ? this.t('joined') : this.t('join')}
+                </rtk-button>
+              )}
               {!this.room.isParent && (
                 <rtk-icon
                   icon={

--- a/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
+++ b/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
@@ -76,7 +76,7 @@ export class RtkChatToggle {
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
     if (!meeting) return;
-    if (usePaginatedChat(meeting)) {
+    if (usePaginatedChat()) {
       meeting.chat?.getMessages(new Date().getTime(), 1, true).then((res) => {
         if (res?.messages?.length) this.hasNewMessages = true;
       });
@@ -144,7 +144,7 @@ export class RtkChatToggle {
     if (!this.canViewChat) return <Host data-hidden />;
     return (
       <Host title={this.t('chat')}>
-        {usePaginatedChat(this.meeting)
+        {usePaginatedChat()
           ? this.hasNewMessages && <div class="unread-count-dot" part="unread-count-dot"></div>
           : this.unreadMessageCount !== 0 &&
             !this.chatActive && (

--- a/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
+++ b/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
@@ -76,11 +76,9 @@ export class RtkChatToggle {
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
     if (!meeting) return;
-    if (usePaginatedChat()) {
-      meeting.chat?.getMessages(new Date().getTime(), 1, true).then((res) => {
-        if (res?.messages?.length) this.hasNewMessages = true;
-      });
-    }
+    meeting.chat?.getMessages(new Date().getTime(), 1, true).then((res) => {
+      if (res?.messages?.length) this.hasNewMessages = true;
+    });
 
     const meetingStartedTimeMs = meeting.meta?.meetingStartedTimestamp.getTime() ?? 0;
     const newMessages = meeting.chat?.messages.filter((m) => m.timeMs > meetingStartedTimeMs);

--- a/packages/core/src/components/rtk-chat/rtk-chat.tsx
+++ b/packages/core/src/components/rtk-chat/rtk-chat.tsx
@@ -27,7 +27,7 @@ import {
   stripOutReplyBlock,
 } from '../../utils/chat';
 import { chatUnreadTimestamps } from '../../utils/user-prefs';
-import { FlagsmithFeatureFlags, usePaginatedChat } from '../../utils/flags';
+import { FlagsmithFeatureFlags } from '../../utils/flags';
 import { RtkChannelHeaderCustomEvent } from '../../components';
 import { States, UIConfig, createDefaultConfig } from '../../exports';
 import { ChannelItem } from '../rtk-channel-selector-view/rtk-channel-selector-view';

--- a/packages/core/src/components/rtk-chat/rtk-chat.tsx
+++ b/packages/core/src/components/rtk-chat/rtk-chat.tsx
@@ -332,7 +332,7 @@ export class RtkChat {
   private usePaginatedChat = () => {
     if (this.isGroupCall && this.showPinnedMessages) return false;
 
-    return this.selectedGroup === 'everyone' && usePaginatedChat(this.meeting);
+    return this.selectedGroup === 'everyone' && usePaginatedChat();
   };
 
   @Watch('chatGroups')

--- a/packages/core/src/components/rtk-chat/rtk-chat.tsx
+++ b/packages/core/src/components/rtk-chat/rtk-chat.tsx
@@ -332,7 +332,7 @@ export class RtkChat {
   private usePaginatedChat = () => {
     if (this.isGroupCall && this.showPinnedMessages) return false;
 
-    return this.selectedGroup === 'everyone' && usePaginatedChat();
+    return this.selectedGroup === 'everyone';
   };
 
   @Watch('chatGroups')

--- a/packages/core/src/utils/flags.ts
+++ b/packages/core/src/utils/flags.ts
@@ -1,5 +1,4 @@
 import RealtimeKitClient from '@cloudflare/realtimekit';
-import { showLivestream } from './livestream';
 
 export const FlagsmithFeatureFlags = {
   PLAY_PARTICIPANT_TILE_VIDEO_ON_PAUSE: 'play_participant_tile_video_on_pause',
@@ -16,10 +15,7 @@ export const FlagsmithFeatureFlags = {
 export const isBreakoutRoomsEnabled = (meeting: RealtimeKitClient) =>
   meeting.connectedMeetings.supportsConnectedMeetings;
 
-export const usePaginatedChat = (meeting: RealtimeKitClient) =>
-  meeting?.meta.viewType === 'CHAT' ||
-  showLivestream(meeting) ||
-  meeting?.__internals__?.features.hasFeature('feat_paginated_chat');
+export const usePaginatedChat = () => true;
 
 export const disableSettingSinkId = (meeting: RealtimeKitClient) =>
   meeting?.__internals__?.browserSpecs.isFirefox() &&


### PR DESCRIPTION
### Description

1. Enabling paginated chat for all, for the public group (everyone). private chats still use non-paginated chat due to some issues.

This PR should unblock the work. We will raise another PR to bring pagination to private chats too. usePaginatedChat method will be removed in future PRs. It exists as of now to prevent merge conflicts.
