### PR TITLE
fix: handle realtime incoming messages for paginated chat

### DIFF
--- a/packages/core/src/components/rtk-paginated-list/rtk-paginated-list.css
+++ b/packages/core/src/components/rtk-paginated-list/rtk-paginated-list.css
@@ -153,13 +153,13 @@ a {
 }
 
 .show-new-messages-ctr {
-  @apply pointer-events-none absolute bottom-2 right-2;
+  @apply absolute bottom-4 right-4;
   @apply z-10 -mt-14;
   @apply translate-y-28 opacity-0 transition;
 }
 
 .show-new-messages-ctr.active {
-  @apply translate-y-0 opacity-100;
+  @apply translate-y-0 cursor-pointer opacity-100;
 }
 
 .show-new-messages {

--- a/packages/core/src/components/rtk-paginated-list/rtk-paginated-list.tsx
+++ b/packages/core/src/components/rtk-paginated-list/rtk-paginated-list.tsx
@@ -62,6 +62,8 @@ export class RtkPaginatedList {
 
   private newTS;
 
+  private maxTS = 0;
+
   /** Page Size */
   @Prop() pageSize: number;
 
@@ -113,7 +115,26 @@ export class RtkPaginatedList {
    * @param {DataNode} node - The data node to add to the beginning of the list
    */
   @Method()
-  async onNewNode(node: DataNode) {}
+  async onNewNode(node: DataNode) {
+    // if we are at the bottom of the page
+    if (this.firstEmptyIndex === -1) {
+      // just append messages to the page if page has not reached full capacity
+      if (this.pages[0].length < this.pageSize) {
+        this.pages[0].unshift(node);
+        this.newTS = node.timeMs;
+        this.rerender();
+      } else {
+        // if page is at full capacity, load next page
+        this.loadNextPage();
+      }
+    }
+    /**
+     * Always update the maxTS.
+     * 1. when we scroll down, new messages will load automatically based on this setting.
+     * 2. new message indicator relies on this value
+     */
+    this.maxTS = Math.max(this.maxTS, node.timeMs);
+  }
 
   /**
    * Deletes a node anywhere from the list
@@ -151,7 +172,12 @@ export class RtkPaginatedList {
     this.observe(this.$topRef);
     if (this.$containerRef) {
       this.$containerRef.onscrollend = () => {
-        if (this.isAtBottom() && this.firstEmptyIndex > -1) {
+        /**
+         * Load new page if:
+         * if there are nodes to load at the bottom (maxTS > newTS)
+         * or if there are pages to fill at the bottom (firstEmptyIndex > -1)
+         */
+        if (this.isAtBottom() && (this.maxTS > this.newTS || this.firstEmptyIndex > -1)) {
           this.loadNextPage();
         }
       };
@@ -217,13 +243,20 @@ export class RtkPaginatedList {
     // no more new messages to load
     if (!data.length) return;
 
-    this.pages[this.firstEmptyIndex] = data.reverse();
+    // when filling empty pages
+    if (this.firstEmptyIndex > -1) {
+      this.pages[this.firstEmptyIndex] = data.reverse();
+    } else {
+      // when already at the bottom and loading messages in realtime
+      this.pages.unshift(data.reverse());
+    }
 
     if (this.pages.length > this.pagesAllowed) {
       this.pages.pop();
     }
 
-    this.newTS = this.pages[this.firstEmptyIndex][0].timeMs;
+    // smallest value for firstEmptyIndex can be -1, so we cap the index at 0
+    this.newTS = this.pages[Math.max(0, this.firstEmptyIndex)][0].timeMs;
 
     // update the old timestamp
     const lastPage = this.pages[this.pages.length - 1];
@@ -231,7 +264,8 @@ export class RtkPaginatedList {
     // when scrolling too fast scroll a bit to the top to be able to load new messages when you scroll down
     if (this.$containerRef.scrollTop === 0) this.$containerRef.scrollTop = -60;
 
-    this.firstEmptyIndex--;
+    // smallest value for this index can be -1 (indicates we are at the bottom of the page).
+    this.firstEmptyIndex = Math.max(-1, this.firstEmptyIndex - 1);
 
     this.rerender();
   }
@@ -249,7 +283,7 @@ export class RtkPaginatedList {
     return (
       <Host>
         <div class="scrollbar container" part="container" ref={(el) => (this.$containerRef = el)}>
-          <div class={'show-new-messages-ctr'}>
+          <div class={{ 'show-new-messages-ctr': true }}>
             <rtk-button
               class="show-new-messages"
               kind="icon"

--- a/packages/core/src/components/rtk-paginated-list/rtk-paginated-list.tsx
+++ b/packages/core/src/components/rtk-paginated-list/rtk-paginated-list.tsx
@@ -111,11 +111,16 @@ export class RtkPaginatedList {
   @State() isLoadingBottom: boolean = false;
 
   /**
-   * Even when auto scroll is enabled, we only want to scroll if a new realtime message has arrived
+   * Even when auto scroll is enabled, we only want to scroll if a new realtime message has arrived.
    * This variable tells us if we should respect auto scroll after a new page has been loaded.
-   * It is also used by the manual scroll to bottom button.
+   * It is also used by the manual scroll to bottom button and the autoScroll prop.
    *  */
   private shouldScrollToBottom: boolean = false;
+
+  /** UI Indicator for "scroll to bottom" button.
+   * Toggles on when a new node is added and autoscroll is disabled.
+   * Toggles off when all nodes are loaded */
+  private showNewMessagesCTR: boolean = false;
 
   /**
    * Adds a new node to the beginning of the paginated list
@@ -142,6 +147,8 @@ export class RtkPaginatedList {
     if (this.autoScroll) {
       this.shouldScrollToBottom = true;
       this.scrollToBottom();
+    } else {
+      this.showNewMessagesCTR = true;
     }
   }
 
@@ -171,10 +178,12 @@ export class RtkPaginatedList {
   connectedCallback() {
     this.rerender = debounce(this.rerender.bind(this), 50, { maxWait: 200 });
     this.intersectionObserver = new IntersectionObserver((entries) => {
-      writeTask(() => {
+      writeTask(async () => {
         for (const entry of entries) {
           if (entry.target.id === 'top-scroll' && entry.isIntersecting) {
-            this.loadPrevPage();
+            this.isLoadingTop = true;
+            await this.loadPrevPage();
+            this.isLoadingTop = false;
           }
         }
       });
@@ -191,7 +200,9 @@ export class RtkPaginatedList {
          * or if there are pages to fill at the bottom (firstEmptyIndex > -1)
          */
         if (this.isAtBottom() && (this.maxTS > this.newTS || this.firstEmptyIndex > -1)) {
+          this.isLoadingBottom = true;
           await this.loadNextPage();
+          this.isLoadingBottom = false;
           if (this.shouldScrollToBottom) this.scrollToBottom();
         }
       };
@@ -204,6 +215,7 @@ export class RtkPaginatedList {
   };
 
   private async loadPrevPage() {
+    if (this.isLoading) return;
     /**
      * NOTE(ikabra): this case also runs on initial load
      * if scrolling up ->
@@ -216,10 +228,8 @@ export class RtkPaginatedList {
 
     // load data
     this.isLoading = true;
-    this.isLoadingTop = true;
     const data = await this.fetchData(this.oldTS - 1, this.pageSize, true);
     this.isLoading = false;
-    this.isLoadingTop = false;
 
     // no more old messages to show, we are at the top of the page
     if (!data.length) return;
@@ -244,21 +254,22 @@ export class RtkPaginatedList {
   }
 
   private async loadNextPage() {
+    if (this.isLoading) return;
     // new timestamp needs to be assigned by loadOld method
     if (!this.newTS) {
+      this.showNewMessagesCTR = false;
       this.shouldScrollToBottom = false;
       return;
     }
 
     // load data
     this.isLoading = true;
-    this.isLoadingBottom = true;
     const data = await this.fetchData(this.newTS + 1, this.pageSize, false);
     this.isLoading = false;
-    this.isLoadingBottom = false;
 
     // no more new messages to load
     if (!data.length) {
+      this.showNewMessagesCTR = false;
       this.shouldScrollToBottom = false;
       return;
     }
@@ -303,12 +314,16 @@ export class RtkPaginatedList {
     return (
       <Host>
         <div class="scrollbar container" part="container" ref={(el) => (this.$containerRef = el)}>
-          <div class={{ 'show-new-messages-ctr': true }}>
+          <div class={{ 'show-new-messages-ctr': true, active: this.showNewMessagesCTR }}>
             <rtk-button
               class="show-new-messages"
               kind="icon"
               variant="secondary"
               part="show-new-messages"
+              onClick={() => {
+                this.shouldScrollToBottom = true;
+                this.scrollToBottom();
+              }}
             >
               <rtk-icon icon={this.iconPack.chevron_down} />
             </rtk-button>

--- a/packages/core/src/components/rtk-paginated-list/rtk-paginated-list.tsx
+++ b/packages/core/src/components/rtk-paginated-list/rtk-paginated-list.tsx
@@ -111,6 +111,13 @@ export class RtkPaginatedList {
   @State() isLoadingBottom: boolean = false;
 
   /**
+   * Even when auto scroll is enabled, we only want to scroll if a new realtime message has arrived
+   * This variable tells us if we should respect auto scroll after a new page has been loaded.
+   * It is also used by the manual scroll to bottom button.
+   *  */
+  private shouldScrollToBottom: boolean = false;
+
+  /**
    * Adds a new node to the beginning of the paginated list
    * @param {DataNode} node - The data node to add to the beginning of the list
    */
@@ -128,12 +135,18 @@ export class RtkPaginatedList {
         this.loadNextPage();
       }
     }
-    /**
-     * Always update the maxTS.
-     * 1. when we scroll down, new messages will load automatically based on this setting.
-     * 2. new message indicator relies on this value
-     */
+    // Always update the maxTS. New messages will load automatically based on this setting.
     this.maxTS = Math.max(this.maxTS, node.timeMs);
+
+    // If autoscroll is enabled this function will scroll to the bottom
+    if (this.autoScroll) {
+      this.shouldScrollToBottom = true;
+      this.scrollToBottom();
+    }
+  }
+
+  private scrollToBottom() {
+    this.$bottomRef.scrollIntoView({ behavior: 'smooth' });
   }
 
   /**
@@ -171,14 +184,15 @@ export class RtkPaginatedList {
   componentDidLoad() {
     this.observe(this.$topRef);
     if (this.$containerRef) {
-      this.$containerRef.onscrollend = () => {
+      this.$containerRef.onscrollend = async () => {
         /**
          * Load new page if:
          * if there are nodes to load at the bottom (maxTS > newTS)
          * or if there are pages to fill at the bottom (firstEmptyIndex > -1)
          */
         if (this.isAtBottom() && (this.maxTS > this.newTS || this.firstEmptyIndex > -1)) {
-          this.loadNextPage();
+          await this.loadNextPage();
+          if (this.shouldScrollToBottom) this.scrollToBottom();
         }
       };
     }
@@ -231,7 +245,10 @@ export class RtkPaginatedList {
 
   private async loadNextPage() {
     // new timestamp needs to be assigned by loadOld method
-    if (!this.newTS) return;
+    if (!this.newTS) {
+      this.shouldScrollToBottom = false;
+      return;
+    }
 
     // load data
     this.isLoading = true;
@@ -241,7 +258,10 @@ export class RtkPaginatedList {
     this.isLoadingBottom = false;
 
     // no more new messages to load
-    if (!data.length) return;
+    if (!data.length) {
+      this.shouldScrollToBottom = false;
+      return;
+    }
 
     // when filling empty pages
     if (this.firstEmptyIndex > -1) {


### PR DESCRIPTION
### Description
This PR addresses a critical production bug where real-time incoming messages were failing to render for users within paginated chat views. 

Core Changes
- Bottom Scrolled: If a user is already at the bottom of the chat, new messages are appended immediately and visibility is maintained.
- Scrolled Up (Auto-scroll ON): If the user has auto-scroll enabled in their settings, the window will now correctly snap to the bottom upon receiving a new event.
- Scrolled Up (Auto-scroll OFF): If the user is viewing historical messages, we show a "New Message" indicator (scroll-down arrow). Clicking this will clear the pagination lag and jump the user to the latest message.
