### PR TITLE
fix: update unread chat counter to work for paginated chat

### DIFF
--- a/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.css
+++ b/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.css
@@ -10,7 +10,7 @@
 }
 
 .unread-count {
-  @apply absolute right-3 box-border p-0.5;
+  @apply absolute right-4 box-border p-0.5;
   @apply select-none;
 
   @apply text-text-sm bg-brand-500 text-text-on-brand;

--- a/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
+++ b/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
@@ -56,6 +56,8 @@ export class RtkChatToggle {
 
   @State() canViewChat: boolean = false;
 
+  private pageSize: number = 11;
+
   connectedCallback() {
     this.meetingChanged(this.meeting);
     this.statesChanged(this.states);
@@ -87,12 +89,13 @@ export class RtkChatToggle {
   private async setUnreadMessageCount() {
     const chat = this.meeting.chat;
     if (!chat) return;
-    const { messages } = await chat.getMessages(new Date().getTime(), 11, true);
+    const { messages } = await chat.getMessages(new Date().getTime(), this.pageSize, true);
 
     const meetingStartedTimeMs = this.meeting.meta?.meetingStartedTimestamp.getTime() ?? 0;
     const newMessages = messages.filter((m) => m.timeMs > meetingStartedTimeMs);
     if (newMessages.length === messages.length && messages.length > 0) {
-      this.unreadMessageCount = 10;
+      // all messages are new, so we can't know the exact count, but we know there are at least pageSize - 1 new messages
+      this.unreadMessageCount = this.pageSize - 1;
     } else {
       this.unreadMessageCount = newMessages.length;
     }
@@ -146,7 +149,7 @@ export class RtkChatToggle {
       <Host title={this.t('chat')}>
         {this.unreadMessageCount !== 0 && !this.chatActive && (
           <div class="unread-count" part="unread-count">
-            <span>{this.unreadMessageCount <= 10 ? this.unreadMessageCount : '10+'}</span>
+            <span>{this.unreadMessageCount < this.pageSize ? this.unreadMessageCount : '10+'}</span>
           </div>
         )}
         <rtk-controlbar-button

--- a/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
+++ b/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
@@ -91,7 +91,7 @@ export class RtkChatToggle {
 
     const meetingStartedTimeMs = this.meeting.meta?.meetingStartedTimestamp.getTime() ?? 0;
     const newMessages = messages.filter((m) => m.timeMs > meetingStartedTimeMs);
-    if (newMessages.length === messages.length) {
+    if (newMessages.length === messages.length && messages.length > 0) {
       this.unreadMessageCount = 10;
     } else {
       this.unreadMessageCount = newMessages.length;

--- a/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
+++ b/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
@@ -3,7 +3,6 @@ import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { Meeting } from '../../types/rtk-client';
 import { Size, States } from '../../types/props';
-import { usePaginatedChat } from '../../utils/flags';
 import { canViewChat } from '../../utils/sidebar';
 import { SyncWithStore } from '../../utils/sync-with-store';
 import { ControlBarVariant } from '../rtk-controlbar-button/rtk-controlbar-button';
@@ -57,11 +56,6 @@ export class RtkChatToggle {
 
   @State() canViewChat: boolean = false;
 
-  /**
-   * Only used when paginated chat is enabled
-   */
-  @State() hasNewMessages: boolean = false;
-
   connectedCallback() {
     this.meetingChanged(this.meeting);
     this.statesChanged(this.states);
@@ -76,15 +70,9 @@ export class RtkChatToggle {
   @Watch('meeting')
   meetingChanged(meeting: Meeting) {
     if (!meeting) return;
-    meeting.chat?.getMessages(new Date().getTime(), 1, true).then((res) => {
-      if (res?.messages?.length) this.hasNewMessages = true;
-    });
-
-    const meetingStartedTimeMs = meeting.meta?.meetingStartedTimestamp.getTime() ?? 0;
-    const newMessages = meeting.chat?.messages.filter((m) => m.timeMs > meetingStartedTimeMs);
-    this.unreadMessageCount = newMessages.length || 0;
-    meeting.chat?.addListener('chatUpdate', this.onChatUpdate);
+    this.setUnreadMessageCount();
     this.canViewChat = canViewChat(meeting);
+    meeting.chat?.addListener('chatUpdate', this.onChatUpdate);
     meeting?.stage?.on('stageStatusUpdate', this.updateCanView);
     meeting?.self?.permissions.on('chatUpdate', this.updateCanView);
   }
@@ -96,24 +84,35 @@ export class RtkChatToggle {
     }
   }
 
+  private async setUnreadMessageCount() {
+    const chat = this.meeting.chat;
+    if (!chat) return;
+    const { messages } = await chat.getMessages(new Date().getTime(), 11, true);
+
+    const meetingStartedTimeMs = this.meeting.meta?.meetingStartedTimestamp.getTime() ?? 0;
+    const newMessages = messages.filter((m) => m.timeMs > meetingStartedTimeMs);
+    if (newMessages.length === messages.length) {
+      this.unreadMessageCount = 10;
+    } else {
+      this.unreadMessageCount = newMessages.length;
+    }
+  }
+
   private onChatUpdate = ({ action, message }) => {
     if (this.chatActive) return;
 
     if (action === 'add' && message.userId !== this.meeting?.self.userId) {
-      this.hasNewMessages = true;
-      this.unreadMessageCount += 1;
+      if (this.unreadMessageCount <= 10) {
+        this.unreadMessageCount += 1;
+      }
     }
   };
-
-  /** Emits updated state data */
-  @Event({ eventName: 'rtkStateUpdate' }) stateUpdate: EventEmitter<States>;
 
   private toggleChat = () => {
     const states = this.states;
     this.chatActive = !(states?.activeSidebar && states?.sidebar === 'chat');
     if (this.chatActive) {
       this.unreadMessageCount = 0;
-      this.hasNewMessages = false;
     }
     this.stateUpdate.emit({
       activeSidebar: this.chatActive,
@@ -135,6 +134,9 @@ export class RtkChatToggle {
     }
   }
 
+  /** Emits updated state data */
+  @Event({ eventName: 'rtkStateUpdate' }) stateUpdate: EventEmitter<States>;
+
   private buttonEl: HTMLRtkControlbarButtonElement;
 
   render() {
@@ -142,14 +144,11 @@ export class RtkChatToggle {
     if (!this.canViewChat) return <Host data-hidden />;
     return (
       <Host title={this.t('chat')}>
-        {usePaginatedChat()
-          ? this.hasNewMessages && <div class="unread-count-dot" part="unread-count-dot"></div>
-          : this.unreadMessageCount !== 0 &&
-            !this.chatActive && (
-              <div class="unread-count" part="unread-count">
-                <span>{this.unreadMessageCount <= 100 ? this.unreadMessageCount : '99+'}</span>
-              </div>
-            )}
+        {this.unreadMessageCount !== 0 && !this.chatActive && (
+          <div class="unread-count" part="unread-count">
+            <span>{this.unreadMessageCount <= 10 ? this.unreadMessageCount : '10+'}</span>
+          </div>
+        )}
         <rtk-controlbar-button
           ref={(el) => (this.buttonEl = el)}
           part="controlbar-button"

--- a/packages/core/src/components/rtk-paginated-list/rtk-paginated-list.tsx
+++ b/packages/core/src/components/rtk-paginated-list/rtk-paginated-list.tsx
@@ -113,11 +113,11 @@ export class RtkPaginatedList {
   /**
    * Even when auto scroll is enabled, we only want to scroll if a new realtime message has arrived.
    * This variable tells us if we should respect auto scroll after a new page has been loaded.
-   * It is also used by the manual scroll to bottom button and the autoScroll prop.
+   * It is also used by the scroll to bottom button.
    *  */
   private shouldScrollToBottom: boolean = false;
 
-  /** UI Indicator for "scroll to bottom" button.
+  /** UI Indicator for the "scroll to bottom" button.
    * Toggles on when a new node is added and autoscroll is disabled.
    * Toggles off when all nodes are loaded */
   private showNewMessagesCTR: boolean = false;
@@ -128,9 +128,12 @@ export class RtkPaginatedList {
    */
   @Method()
   async onNewNode(node: DataNode) {
+    // Always update the maxTS. New messages will load on scroll till the end cursor (newTS) reaches this value.
+    this.maxTS = Math.max(this.maxTS, node.timeMs);
+
     // if we are at the bottom of the page
     if (this.firstEmptyIndex === -1) {
-      // just append messages to the page if page has not reached full capacity
+      // append messages to the page if page has not reached full capacity
       if (this.pages[0].length < this.pageSize) {
         this.pages[0].unshift(node);
         this.newTS = node.timeMs;
@@ -140,10 +143,8 @@ export class RtkPaginatedList {
         this.loadNextPage();
       }
     }
-    // Always update the maxTS. New messages will load automatically based on this setting.
-    this.maxTS = Math.max(this.maxTS, node.timeMs);
 
-    // If autoscroll is enabled this function will scroll to the bottom
+    // If autoscroll is enabled, this method will scroll to the bottom
     if (this.autoScroll) {
       this.shouldScrollToBottom = true;
       this.scrollToBottom();
@@ -152,6 +153,7 @@ export class RtkPaginatedList {
     }
   }
 
+  // this method is called recursively based on shouldScrollToBottom (see scrollEnd listener)
   private scrollToBottom() {
     this.$bottomRef.scrollIntoView({ behavior: 'smooth' });
   }
@@ -255,7 +257,7 @@ export class RtkPaginatedList {
 
   private async loadNextPage() {
     if (this.isLoading) return;
-    // new timestamp needs to be assigned by loadOld method
+    // new timestamp needs to be assigned by loadPrevPage method
     if (!this.newTS) {
       this.showNewMessagesCTR = false;
       this.shouldScrollToBottom = false;


### PR DESCRIPTION
### Description
This PR updates the chat unread badge logic to support paginated chat. Since non-paginated chat is deprecated, the badge now correctly reflects unread states even when the full message history isn't loaded.

#### Changes:
- Count Capping: Implemented a UI cap for the badge. To maintain performance and UI consistency, the badge will now display "10+" for any unread count exceeding 10.

#### Out of Scope (To be addressed in subsequent PRs):
- Fixing the unread message count in the chat channel selector. Currently that seems to be broken for paginated chat as well. Track https://jira.cfdata.org/browse/RTK-7393

### Screenshots
<img width="345" height="96" alt="Screenshot 2026-01-15 at 10 41 33 PM" src="https://github.com/user-attachments/assets/760463d7-15f6-4aeb-b75c-35e3b094a7b7" />
<img width="345" height="96" alt="Screenshot 2026-01-15 at 10 42 07 PM" src="https://github.com/user-attachments/assets/a2f286c8-8925-46bf-a798-77c5bff01ac4" />
