### PR TITLE
fix: ui nuances in chat messages

### DIFF
--- a/packages/angular-library/projects/components/src/lib/stencil-generated/components.ts
+++ b/packages/angular-library/projects/components/src/lib/stencil-generated/components.ts
@@ -670,14 +670,14 @@ export declare interface RtkChatComposerUi extends Components.RtkChatComposerUi 
 
 
 @ProxyCmp({
-  inputs: ['canSendFiles', 'canSendTextMessage', 'disableEmojiPicker', 'iconPack', 'inputTextPlaceholder', 'isEditing', 'maxLength', 'message', 'quotedMessage', 'rateLimits', 'storageKey', 't']
+  inputs: ['canSendFiles', 'canSendTextMessage', 'disableEmojiPicker', 'iconPack', 'inputTextPlaceholder', 'isEditing', 'isSending', 'maxLength', 'message', 'quotedMessage', 'rateLimits', 'storageKey', 't']
 })
 @Component({
   selector: 'rtk-chat-composer-view',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['canSendFiles', 'canSendTextMessage', 'disableEmojiPicker', 'iconPack', 'inputTextPlaceholder', 'isEditing', 'maxLength', 'message', 'quotedMessage', 'rateLimits', 'storageKey', 't'],
+  inputs: ['canSendFiles', 'canSendTextMessage', 'disableEmojiPicker', 'iconPack', 'inputTextPlaceholder', 'isEditing', 'isSending', 'maxLength', 'message', 'quotedMessage', 'rateLimits', 'storageKey', 't'],
 })
 export class RtkChatComposerView {
   protected el: HTMLRtkChatComposerViewElement;
@@ -2076,14 +2076,14 @@ export declare interface RtkMessageListView extends Components.RtkMessageListVie
 
 
 @ProxyCmp({
-  inputs: ['actions', 'authorName', 'avatarUrl', 'hideAuthorName', 'hideAvatar', 'hideMetadata', 'iconPack', 'isSelf', 'pinned', 'time', 'variant', 'viewType']
+  inputs: ['actions', 'authorName', 'avatarUrl', 'hideAuthorName', 'hideAvatar', 'hideMetadata', 'iconPack', 'isEdited', 'isSelf', 'messageType', 'pinned', 'time', 'variant', 'viewType']
 })
 @Component({
   selector: 'rtk-message-view',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['actions', 'authorName', 'avatarUrl', 'hideAuthorName', 'hideAvatar', 'hideMetadata', 'iconPack', 'isSelf', 'pinned', 'time', 'variant', 'viewType'],
+  inputs: ['actions', 'authorName', 'avatarUrl', 'hideAuthorName', 'hideAvatar', 'hideMetadata', 'iconPack', 'isEdited', 'isSelf', 'messageType', 'pinned', 'time', 'variant', 'viewType'],
 })
 export class RtkMessageView {
   protected el: HTMLRtkMessageViewElement;

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -765,6 +765,7 @@ export namespace Components {
           * Sets composer to edit mode
          */
         "isEditing": boolean;
+        "isSending": boolean;
         /**
           * Max length for text input
          */
@@ -2150,9 +2151,17 @@ export namespace Components {
          */
         "iconPack": IconPack1;
         /**
+          * Has the message been edited
+         */
+        "isEdited": boolean;
+        /**
           * Is the message sent by the current user
          */
         "isSelf": boolean;
+        /**
+          * Type of message
+         */
+        "messageType": Message['type'];
         /**
           * Is message pinned
          */
@@ -7437,6 +7446,7 @@ declare namespace LocalJSX {
           * Sets composer to edit mode
          */
         "isEditing"?: boolean;
+        "isSending"?: boolean;
         /**
           * Max length for text input
          */
@@ -8999,9 +9009,17 @@ declare namespace LocalJSX {
          */
         "iconPack"?: IconPack1;
         /**
+          * Has the message been edited
+         */
+        "isEdited"?: boolean;
+        /**
           * Is the message sent by the current user
          */
         "isSelf"?: boolean;
+        /**
+          * Type of message
+         */
+        "messageType"?: Message['type'];
         /**
           * action event
          */

--- a/packages/core/src/components/rtk-chat-composer-view/rtk-chat-composer-view.tsx
+++ b/packages/core/src/components/rtk-chat-composer-view/rtk-chat-composer-view.tsx
@@ -35,6 +35,8 @@ export class RtkChatComposerView {
   /** Whether user can send text messages */
   @Prop() canSendTextMessage = true;
 
+  @Prop() isSending: boolean = false;
+
   /** Whether user can send file messages */
   @Prop() canSendFiles = true;
 
@@ -154,15 +156,7 @@ export class RtkChatComposerView {
     this.checkRateLimitBreached(currentTime);
 
     if (message.length > 0) {
-      if (this.quotedMessage.length !== 0) {
-        this.onNewMessage.emit({
-          type: 'text',
-          message,
-        });
-      } else {
-        this.onNewMessage.emit({ type: 'text', message });
-      }
-
+      this.onNewMessage.emit({ type: 'text', message });
       this.cleanup();
     }
   };
@@ -328,11 +322,15 @@ export class RtkChatComposerView {
                 <rtk-tooltip variant="primary" label={this.t('chat.send_msg')} delay={2000}>
                   <rtk-button
                     kind="icon"
-                    disabled={this.disableSendButton}
+                    disabled={this.disableSendButton || this.isSending}
                     onClick={() => this.handleSendMessage()}
                     title={this.t('chat.send_msg')}
                   >
-                    <rtk-icon icon={this.iconPack.send} />
+                    {this.isSending ? (
+                      <rtk-spinner size="sm" />
+                    ) : (
+                      <rtk-icon icon={this.iconPack.send} />
+                    )}
                   </rtk-button>
                 </rtk-tooltip>
               )}
@@ -354,7 +352,11 @@ export class RtkChatComposerView {
                       onClick={() => this.handleEditMessage()}
                       title={this.t('chat.send_msg')}
                     >
-                      <rtk-icon icon={this.iconPack.checkmark} />
+                      {this.isSending ? (
+                        <rtk-spinner size="sm" />
+                      ) : (
+                        <rtk-icon icon={this.iconPack.checkmark} />
+                      )}
                     </rtk-button>
                   </rtk-tooltip>
                 </div>

--- a/packages/core/src/components/rtk-chat-messages-ui-paginated/rtk-chat-messages-ui-paginated.tsx
+++ b/packages/core/src/components/rtk-chat-messages-ui-paginated/rtk-chat-messages-ui-paginated.tsx
@@ -231,7 +231,9 @@ export class RtkChatMessagesUiPaginated {
       <div>
         <div class="message-wrapper" id={message.id}>
           <rtk-message-view
+            messageType={message.type}
             pinned={message.pinned}
+            isEdited={message.isEdited}
             time={message.time}
             actions={this.getMessageActions(message)}
             authorName={message.displayName}

--- a/packages/core/src/components/rtk-chat/rtk-chat.css
+++ b/packages/core/src/components/rtk-chat/rtk-chat.css
@@ -125,7 +125,7 @@ rtk-chat-composer-view {
 
 .pinned-messages-content {
   @apply bg-background-1000 border-background-600;
-  @apply absolute left-0 top-full z-50 w-full;
+  @apply absolute left-0 top-full z-50 max-h-[30vh] w-full overflow-auto;
 }
 
 .pinned-message {

--- a/packages/core/src/components/rtk-chat/rtk-chat.tsx
+++ b/packages/core/src/components/rtk-chat/rtk-chat.tsx
@@ -568,6 +568,26 @@ export class RtkChat {
 
   private onDeleteMessage = (event: CustomEvent<Message>) => {
     const message = event.detail;
+
+    if (this.editingMessage?.id === message.id) {
+      this.editingMessage = null;
+    }
+
+    try {
+      if (typeof localStorage !== 'undefined') {
+        const keysToRemove: string[] = [];
+        for (let i = 0; i < localStorage.length; i++) {
+          const key = localStorage.key(i);
+          if (key && key.startsWith('rtk-chat-edit-') && key.endsWith(`-${message.id}`)) {
+            keysToRemove.push(key);
+          }
+        }
+        keysToRemove.forEach((key) => localStorage.removeItem(key));
+      }
+    } catch {
+      // ignore storage access errors
+    }
+
     this.meeting.chat.deleteMessage(message.id);
   };
 

--- a/packages/core/src/components/rtk-chat/rtk-chat.tsx
+++ b/packages/core/src/components/rtk-chat/rtk-chat.tsx
@@ -148,6 +148,8 @@ export class RtkChat {
 
   @State() creatingChannel = false;
 
+  @State() isSendingMessage = false;
+
   @State() showPinnedMessages: boolean = false;
 
   /** Emits updated state data */
@@ -529,16 +531,26 @@ export class RtkChat {
 
   private onNewMessageHandler = async (e: CustomEvent<NewMessageEvent>) => {
     const message = e.detail;
-    this.meeting.chat.sendMessage(message, this.getRecipientPeerIds());
+    this.isSendingMessage = true;
+    try {
+      await this.meeting.chat.sendMessage(message, this.getRecipientPeerIds());
+    } finally {
+      this.isSendingMessage = false;
+    }
   };
 
   private onEditMessageHandler = async (e: CustomEvent<string>) => {
-    await this.meeting?.chat?.editTextMessage(
-      this.editingMessage.id,
-      e.detail,
-      this.editingMessage.channelId
-    );
-    this.editingMessage = null;
+    this.isSendingMessage = true;
+    try {
+      await this.meeting?.chat?.editTextMessage(
+        this.editingMessage.id,
+        e.detail,
+        this.editingMessage.channelId
+      );
+    } finally {
+      this.isSendingMessage = false;
+      this.editingMessage = null;
+    }
   };
 
   private onEditCancel = () => {
@@ -592,6 +604,7 @@ export class RtkChat {
         storageKey={storageKey}
         quotedMessage={quotedMessage}
         isEditing={!!this.editingMessage}
+        isSending={this.isSendingMessage}
         canSendTextMessage={this.isTextMessagingAllowed()}
         canSendFiles={this.isFileMessagingAllowed()}
         disableEmojiPicker={this.overrides.disableEmojiPicker}
@@ -659,7 +672,7 @@ export class RtkChat {
           />
         </div>
         {this.showPinnedMessages && (
-          <div class="pinned-messages-content">
+          <div class="pinned-messages-content scrollbar">
             {this.meeting.chat.pinned.map((message) => {
               const label = this.getPinnedMessageLabel(message as Message);
               return (

--- a/packages/core/src/components/rtk-message-view/rtk-message-view.css
+++ b/packages/core/src/components/rtk-message-view/rtk-message-view.css
@@ -52,9 +52,12 @@
 }
 
 .metadata {
-  @apply mt-2 flex flex-row items-center gap-2;
+  @apply mt-2 flex flex-row items-center gap-1;
   @apply self-end;
   @apply text-text-800 text-[11px];
+}
+.metadata-content {
+  @apply flex flex-row items-center gap-1;
 }
 
 .avatar {

--- a/packages/core/src/components/rtk-message-view/rtk-message-view.tsx
+++ b/packages/core/src/components/rtk-message-view/rtk-message-view.tsx
@@ -2,6 +2,7 @@ import { Component, Event, EventEmitter, Host, Prop, h } from '@stencil/core';
 import { elapsedDuration, formatDateTime } from '../../utils/date';
 import { SyncWithStore } from '../../utils/sync-with-store';
 import { IconPack, defaultIconPack } from '../../exports';
+import { Message } from '@cloudflare/realtimekit';
 
 export interface MessageAction {
   id: string;
@@ -17,6 +18,12 @@ export interface MessageAction {
 export class RtkMessageView {
   /** List of actions to show in menu */
   @Prop() actions: MessageAction[] = [];
+
+  /** Type of message */
+  @Prop() messageType: Message['type'];
+
+  /** Has the message been edited */
+  @Prop() isEdited: boolean;
 
   /** Appearance */
   @Prop() variant: 'plain' | 'bubble' = 'bubble';
@@ -63,15 +70,18 @@ export class RtkMessageView {
           <rtk-icon icon={this.iconPack.chevron_down} />
         </button>
         <rtk-menu-list menuVariant={this.isSelf ? 'primary' : 'secondary'}>
-          {this.actions.map((action) => (
-            <rtk-menu-item
-              menuVariant={this.isSelf ? 'primary' : 'secondary'}
-              onClick={() => this.onAction.emit(action.id)}
-            >
-              {action.icon && <rtk-icon icon={action.icon} slot="start" />}
-              {action.label}
-            </rtk-menu-item>
-          ))}
+          {this.actions.map((action) => {
+            if (action.id === 'edit_message' && this.messageType !== 'text') return;
+            return (
+              <rtk-menu-item
+                menuVariant={this.isSelf ? 'primary' : 'secondary'}
+                onClick={() => this.onAction.emit(action.id)}
+              >
+                {action.icon && <rtk-icon icon={action.icon} slot="start" />}
+                {action.label}
+              </rtk-menu-item>
+            );
+          })}
         </rtk-menu-list>
       </rtk-menu>
     );
@@ -99,7 +109,16 @@ export class RtkMessageView {
               <slot></slot>
               {!this.hideMetadata && !!this.time && (
                 <div class="metadata" title={formatDateTime(this.time)}>
-                  {this.pinned && <rtk-icon icon={this.iconPack.pin} size="sm" />}
+                  {this.pinned && (
+                    <span class="metadata-content">
+                      <rtk-icon icon={this.iconPack.pin} size="sm" /> •
+                    </span>
+                  )}
+                  {this.isEdited && (
+                    <span class="metadata-content">
+                      <span>Edited</span> •
+                    </span>
+                  )}
                   {elapsedDuration(this.time, new Date(Date.now()))}
                 </div>
               )}

--- a/packages/core/src/components/rtk-paginated-list/rtk-paginated-list.tsx
+++ b/packages/core/src/components/rtk-paginated-list/rtk-paginated-list.tsx
@@ -53,11 +53,14 @@ export class RtkPaginatedList {
 
   private $bottomRef: HTMLDivElement;
 
-  private oldTS;
+  // Timestamp pertaining to the oldest stored message
+  private oldestPaginatedTimestamp: number | null = null;
 
-  private newTS;
+  // Timestamp pertaining to the latest stored message
+  private latestPaginatedTimestamp: number | null = null;
 
-  private maxTS;
+  // Timestamp pertaining to the latest message stored in backend
+  private latestMessageTimestamp: number | null = null;
 
   // the length of pages will always be pageSize + 2
   private pages: any[][] = [];
@@ -119,29 +122,29 @@ export class RtkPaginatedList {
   async onNewNode(node: DataNode) {
     // if there are no pages, append to the first page
     if (this.pages.length < 1) {
-      this.oldTS = node.timeMs;
+      this.oldestPaginatedTimestamp = node.timeMs;
       this.pages.unshift([node]);
-      this.newTS = node.timeMs;
-      this.maxTS = node.timeMs;
+      this.latestPaginatedTimestamp = node.timeMs;
+      this.latestMessageTimestamp = node.timeMs;
       this.rerender();
       if (this.autoScroll) this.$bottomRef.scrollIntoView({ behavior: 'smooth' });
-    } else if (this.maxTS === this.newTS) {
-      this.maxTS = node.timeMs;
+    } else if (this.latestMessageTimestamp === this.latestPaginatedTimestamp) {
       // append messages to the page if page has not reached full capacity
       if (this.pages[0].length < this.pageSize) {
         this.pages[0].unshift(node);
-        this.newTS = node.timeMs;
+        this.latestPaginatedTimestamp = node.timeMs;
+        this.latestMessageTimestamp = node.timeMs;
         this.rerender();
       } else {
         // if page is at full capacity, load next page
         this.pages.unshift([node]);
-        this.newTS = node.timeMs;
+        this.latestPaginatedTimestamp = node.timeMs;
+        this.latestMessageTimestamp = node.timeMs;
         // remove pages if out of bounds
         if (this.pages.length > this.pagesAllowed) this.pages.pop();
         // update timestamps
         const lastPage = this.pages[this.pages.length - 1];
-        this.oldTS = (lastPage[lastPage.length - 1] as any).timeMs;
-        this.newTS = this.pages[0][0].timeMs;
+        this.oldestPaginatedTimestamp = (lastPage[lastPage.length - 1] as any).timeMs;
         this.rerender();
       }
       if (this.autoScroll) this.$bottomRef.scrollIntoView({ behavior: 'smooth' });
@@ -168,10 +171,10 @@ export class RtkPaginatedList {
       // update timestamps
       const firstPage = this.pages[0];
       const lastPage = this.pages[this.pages.length - 1];
-      this.newTS = firstPage?.[0]?.timeMs;
-      this.oldTS = lastPage?.[lastPage.length - 1]?.timeMs;
-      // if I have deleted the latest message, update maxTS
-      if (index === 0 && i === 0) this.maxTS = this.newTS;
+      this.latestPaginatedTimestamp = firstPage?.[0]?.timeMs;
+      this.oldestPaginatedTimestamp = lastPage?.[lastPage.length - 1]?.timeMs;
+      // if I have deleted the latest message, update latestMessageTimestamp
+      if (index === 0 && i === 0) this.latestMessageTimestamp = this.latestPaginatedTimestamp;
       this.rerender();
       break;
     }
@@ -210,7 +213,10 @@ export class RtkPaginatedList {
         // do not do anything if we are scrolling to bottom
         if (this.shouldScrollToBottom) return;
         // handle top and bottom scroll
-        if (this.isInView(this.$bottomRef)) {
+        if (
+          this.isInView(this.$bottomRef) &&
+          this.latestMessageTimestamp > this.latestPaginatedTimestamp
+        ) {
           await this.loadNextPage();
         } else if (this.isInView(this.$topRef)) {
           this.showNewMessagesCTR = true;
@@ -233,12 +239,12 @@ export class RtkPaginatedList {
     const scrollAnchor = this.getScrollAnchor('top');
 
     // if no old timestamp, it means we are at initial state
-    if (!this.oldTS) this.oldTS = new Date().getTime();
+    if (!this.oldestPaginatedTimestamp) this.oldestPaginatedTimestamp = new Date().getTime();
 
     // load data
     this.isLoading = true;
     this.isLoadingTop = true;
-    const data = await this.fetchData(this.oldTS - 1, this.pageSize, true);
+    const data = await this.fetchData(this.oldestPaginatedTimestamp - 1, this.pageSize, true);
     this.isLoading = false;
     this.isLoadingTop = false;
 
@@ -253,9 +259,9 @@ export class RtkPaginatedList {
 
     // update timestamps
     const lastPage = this.pages[this.pages.length - 1];
-    this.oldTS = (lastPage[lastPage.length - 1] as any).timeMs;
-    this.newTS = this.pages[0][0].timeMs;
-    if (!this.maxTS) this.maxTS = this.newTS;
+    this.oldestPaginatedTimestamp = (lastPage[lastPage.length - 1] as any).timeMs;
+    this.latestPaginatedTimestamp = this.pages[0][0].timeMs;
+    if (!this.latestMessageTimestamp) this.latestMessageTimestamp = this.latestPaginatedTimestamp;
 
     this.rerender();
 
@@ -267,7 +273,7 @@ export class RtkPaginatedList {
     if (this.isLoading) return [];
 
     // Do nothing. New timestamp needs to be assigned by loadPrevPage method
-    if (!this.newTS) {
+    if (!this.latestPaginatedTimestamp) {
       this.showNewMessagesCTR = false;
       return [];
     }
@@ -277,13 +283,13 @@ export class RtkPaginatedList {
 
     const scrollAnchor = this.getScrollAnchor('bottom');
 
-    const data = await this.fetchData(this.newTS + 1, this.pageSize, false);
+    const data = await this.fetchData(this.latestPaginatedTimestamp + 1, this.pageSize, false);
     this.isLoading = false;
     this.isLoadingBottom = false;
 
     // no more new messages to load
     if (!data.length) {
-      this.maxTS = this.newTS;
+      this.latestMessageTimestamp = this.latestPaginatedTimestamp;
       this.showNewMessagesCTR = false;
       return [];
     }
@@ -310,8 +316,8 @@ export class RtkPaginatedList {
 
     // update timestamps
     const lastPage = this.pages[this.pages.length - 1];
-    this.oldTS = (lastPage[lastPage.length - 1] as any).timeMs;
-    this.newTS = this.pages[0][0].timeMs;
+    this.oldestPaginatedTimestamp = (lastPage[lastPage.length - 1] as any).timeMs;
+    this.latestPaginatedTimestamp = this.pages[0][0].timeMs;
 
     this.rerender();
     this.pendingScrollAnchor = scrollAnchor;
@@ -413,7 +419,11 @@ export class RtkPaginatedList {
                 this.scrollToBottom();
               }}
             >
-              <rtk-icon icon={this.iconPack.chevron_down} />
+              {this.shouldScrollToBottom ? (
+                <rtk-spinner size="sm" />
+              ) : (
+                <rtk-icon icon={this.iconPack.chevron_down} />
+              )}
             </rtk-button>
           </div>
           <div


### PR DESCRIPTION
### Description
This PR fixes minor UI nuances with chat messages.
Changes
1. Edited messages now show an "edited" label
2. Edit Action is now not available for images/files
3. Made pinned messages dropdown scrollable
4. Added loaders for when chat messages are being sent (useful in case of sending files/images)
5. Fixed: File messages are sometimes shown twice in the UI
6. If a chat message gets deleted while a user is editing it, it should get cleared from the composer.