### PR TITLE
fix: DONT MERGE, AI SLOP don't refocus sidebar toggle buttons when AI panel opens

### DIFF
--- a/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
+++ b/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
@@ -128,8 +128,8 @@ export class RtkChatToggle {
 
   @Watch('chatActive')
   handleChatActiveChange() {
-    // Chat sidebar closed without opening a different sidebar
-    if (!this.chatActive && !this.states.activeSidebar) {
+    // Chat sidebar closed without opening a different sidebar or AI panel
+    if (!this.chatActive && !this.states.activeSidebar && !this.states.activeAI) {
       this.buttonEl.focus();
     }
   }

--- a/packages/core/src/components/rtk-participants-toggle/rtk-participants-toggle.tsx
+++ b/packages/core/src/components/rtk-participants-toggle/rtk-participants-toggle.tsx
@@ -164,8 +164,8 @@ export class RtkParticipantsToggle {
 
   @Watch('participantsActive')
   handleParticipantsActiveChange() {
-    // Participants sidebar closed without opening a different sidebar
-    if (!this.participantsActive && !this.states.activeSidebar) {
+    // Participants sidebar closed without opening a different sidebar or AI panel
+    if (!this.participantsActive && !this.states.activeSidebar && !this.states.activeAI) {
       this.buttonEl.focus();
     }
   }

--- a/packages/core/src/components/rtk-plugins-toggle/rtk-plugins-toggle.tsx
+++ b/packages/core/src/components/rtk-plugins-toggle/rtk-plugins-toggle.tsx
@@ -97,8 +97,8 @@ export class RtkPluginsToggle {
 
   @Watch('pluginsActive')
   handlePluginsActiveChange() {
-    // Plugins sidebar closed without opening a different sidebar
-    if (!this.pluginsActive && !this.states.activeSidebar) {
+    // Plugins sidebar closed without opening a different sidebar or AI panel
+    if (!this.pluginsActive && !this.states.activeSidebar && !this.states.activeAI) {
       this.buttonEl.focus();
     }
   }

--- a/packages/core/src/components/rtk-polls-toggle/rtk-polls-toggle.tsx
+++ b/packages/core/src/components/rtk-polls-toggle/rtk-polls-toggle.tsx
@@ -111,8 +111,8 @@ export class RtkPollsToggle {
 
   @Watch('pollsActive')
   handlePollsActiveChange() {
-    // Polls sidebar closed without opening a different sidebar
-    if (!this.pollsActive && !this.states.activeSidebar) {
+    // Polls sidebar closed without opening a different sidebar or AI panel
+    if (!this.pollsActive && !this.states.activeSidebar && !this.states.activeAI) {
       this.buttonEl.focus();
     }
   }


### PR DESCRIPTION
When a sidebar toggle (Chat, Polls, Participants, Plugins) was active and the user clicked Meeting AI, the focus-return watcher would fire (since activeSidebar became false) and call buttonEl.focus() on the deactivated toggle. This caused the button to appear visually selected due to focus styles matching the active state.

Fix: add !this.states.activeAI guard so focus is only returned to the sidebar button when the user truly closes the sidebar without switching to another panel or the AI panel.

Fixes RTK-7711

### Description

<!-- Add description of changes made -->

### Screenshots

<!-- Add screenshots if applicable -->
