### PR TITLE
fix: show network errors in the setup screen

### DIFF
--- a/packages/core/src/components/rtk-idle-screen/rtk-idle-screen.css
+++ b/packages/core/src/components/rtk-idle-screen/rtk-idle-screen.css
@@ -9,6 +9,14 @@
   @apply flex flex-col items-center gap-8;
 }
 
+.no-network-badge {
+  @apply bg-brand-500 text-text-sm text-danger/75 bg-danger/10 mt-2 flex w-full flex-row items-center justify-start rounded-sm py-1;
+
+  rtk-icon {
+    @apply mx-2;
+  }
+}
+
 rtk-logo.loaded {
   @apply h-12;
 }

--- a/packages/core/src/components/rtk-idle-screen/rtk-idle-screen.tsx
+++ b/packages/core/src/components/rtk-idle-screen/rtk-idle-screen.tsx
@@ -1,10 +1,12 @@
-import { Component, Host, h, Prop } from '@stencil/core';
+import { Component, Host, h, Prop, State, Watch } from '@stencil/core';
 import { createDefaultConfig } from '../../exports';
 import { IconPack, defaultIconPack } from '../../lib/icons';
 import { useLanguage, RtkI18n } from '../../lib/lang';
 import { UIConfig } from '../../types/ui-config';
 import { SyncWithStore } from '../../utils/sync-with-store';
 import { Meeting } from '../../types/rtk-client';
+import { SocketConnectionState } from '@cloudflare/realtimekit';
+import { States } from '../../types/props';
 
 /**
  * A screen that handles the idle state,
@@ -21,6 +23,11 @@ export class RtkIdleScreen {
   @Prop()
   meeting: Meeting;
 
+  /** States object */
+  @SyncWithStore()
+  @Prop()
+  states: States;
+
   /** Config object */
   @SyncWithStore()
   @Prop()
@@ -36,17 +43,75 @@ export class RtkIdleScreen {
   @Prop()
   t: RtkI18n = useLanguage();
 
+  @State() joinError: string | undefined;
+
+  @State() connectionState: SocketConnectionState['state'];
+
+  connectedCallback() {
+    this.meetingChanged(this.meeting, undefined);
+    this.statesChanged(this.states);
+  }
+
+  disconnectedCallback() {
+    this.meeting?.meta?.removeListener('socketConnectionUpdate', this.socketStateUpdate);
+  }
+
+  @Watch('meeting')
+  meetingChanged(meeting: Meeting, oldMeeting?: Meeting) {
+    oldMeeting?.meta?.removeListener('socketConnectionUpdate', this.socketStateUpdate);
+
+    if (!meeting) return;
+
+    this.connectionState = meeting.meta?.socketState?.state;
+    meeting.meta?.addListener('socketConnectionUpdate', this.socketStateUpdate);
+  }
+
+  private socketStateUpdate = ({ state }: SocketConnectionState) => {
+    this.connectionState = state;
+    if (state === 'connected') {
+      if (!this.states?.joinError) {
+        this.joinError = undefined;
+      }
+    }
+  };
+
+  @Watch('states')
+  statesChanged(states: States) {
+    this.joinError = states?.joinError;
+  }
+
   render() {
+    const showSocketError =
+      !!this.connectionState && this.connectionState !== 'connected' && !this.joinError;
+
+    const errorText = this.joinError
+      ? this.joinError
+      : this.connectionState === 'failed'
+      ? this.t('network.lost_extended')
+      : this.t('network.lost');
+
     return (
       <Host>
         <slot>
           <div class="ctr" part="container">
             <rtk-logo meeting={this.meeting} config={this.config} t={this.t} part="logo" />
-            <rtk-spinner
-              aria-label="Idle, waiting for meeting data"
-              part="spinner"
-              iconPack={this.iconPack}
-            />
+            {this.joinError || showSocketError ? (
+              <div class="no-network-badge" part="network-badge">
+                <rtk-icon
+                  size="md"
+                  variant="danger"
+                  icon={this.iconPack.disconnected}
+                  part="network-badge-icon"
+                ></rtk-icon>
+                {errorText}
+              </div>
+            ) : (
+              <rtk-spinner
+                aria-label="Idle, waiting for meeting data"
+                part="spinner"
+                iconPack={this.iconPack}
+              />
+            )}
           </div>
         </slot>
       </Host>

--- a/packages/core/src/components/rtk-meeting/rtk-meeting.tsx
+++ b/packages/core/src/components/rtk-meeting/rtk-meeting.tsx
@@ -42,7 +42,7 @@ export class RtkMeeting {
   private providerId: string = 'provider-' + Math.floor(Math.random() * 100);
 
   private roomJoinedListener = () => {
-    this.updateStates({ meeting: 'joined' });
+    this.updateStates({ meeting: 'joined', joinError: undefined });
   };
 
   private waitlistedListener = () => {
@@ -317,7 +317,15 @@ export class RtkMeeting {
       if (this.showSetupScreen) {
         this.updateStates({ meeting: 'setup' });
       } else {
-        meeting.joinRoom();
+        meeting
+          .joinRoom()
+          .then(() => {
+            this.updateStates({ joinError: undefined });
+          })
+          .catch((err) => {
+            const message = err?.message ? err.message : this.t('network.lost_extended');
+            this.updateStates({ joinError: message });
+          });
       }
     }
 

--- a/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.tsx
+++ b/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.tsx
@@ -67,6 +67,8 @@ export class RtkSetupScreen {
 
   @State() isJoining: boolean = false;
 
+  @State() joinError?: string;
+
   @State() canEditName: boolean = true;
 
   @State() canProduceAudio: boolean = true;
@@ -97,12 +99,26 @@ export class RtkSetupScreen {
 
   private socketStateUpdate = ({ state }: SocketConnectionState) => {
     this.connectionState = state;
+    if (state === 'connected') {
+      this.joinError = undefined;
+    }
     if (state === 'failed') this.isJoining = false;
   };
 
   private join = async () => {
     if (this.displayName?.trim() !== '' && !this.isJoining) {
+      if (this.connectionState !== 'connected') {
+        if (this.connectionState) {
+          this.joinError =
+            this.connectionState === 'failed'
+              ? this.t('network.lost_extended')
+              : this.t('network.lost');
+        }
+        return;
+      }
+
       this.isJoining = true;
+      this.joinError = undefined;
       this.meeting?.self.setName(this.displayName);
 
       gracefulStorage.setItem('rtk-display-name', this.displayName);
@@ -110,6 +126,7 @@ export class RtkSetupScreen {
         await this.meeting?.joinRoom();
       } catch (e) {
         this.isJoining = false;
+        this.joinError = e?.message ? e.message : this.t('network.lost_extended');
       }
     }
   };
@@ -118,6 +135,15 @@ export class RtkSetupScreen {
     if (!this.meeting) {
       return;
     }
+
+    const showSocketError =
+      !!this.connectionState && this.connectionState !== 'connected' && !this.joinError;
+
+    const errorText = this.joinError
+      ? this.joinError
+      : this.connectionState === 'failed'
+      ? this.t('network.lost_extended')
+      : this.t('network.lost');
 
     const disabled =
       this.displayName?.trim() === '' || this.connectionState !== 'connected' || this.isJoining;
@@ -186,12 +212,10 @@ export class RtkSetupScreen {
               {this.isJoining ? <rtk-spinner iconPack={this.iconPack} /> : this.t('join')}
             </rtk-button>
 
-            {this.connectionState !== 'connected' && (
+            {(this.joinError || showSocketError) && (
               <div class="no-network-badge">
                 <rtk-icon size="md" variant="danger" icon={this.iconPack.disconnected}></rtk-icon>
-                {this.connectionState === 'failed'
-                  ? this.t('network.lost_extended')
-                  : this.t('network.lost')}
+                {errorText}
               </div>
             )}
           </div>

--- a/packages/core/src/types/props.ts
+++ b/packages/core/src/types/props.ts
@@ -81,6 +81,7 @@ export interface States {
   prefs?: UserPreferences;
   sidebar?: RtkSidebarSection;
   roomLeftState?: RoomLeftState | 'unauthorized';
+  joinError?: string;
   sidebarFloating?: boolean;
   participantsTabId?: ParticipantsTabId;
   [state: string]: any;


### PR DESCRIPTION
### Description
When the join room flow fails, we do not show any errors. This PR fixes that.
Here is a simulation of two cases:
1. firewalls blocking WebRTC connection IP addresses
2. join room failures despite a successful web socket connection

### Screenshots
(Please note the error messages have been fixed and formatted in the corresponding Realtimekit PR
https://github.com/cloudflare/realtimekit/pull/2019)

<img width="1363" height="894" alt="Screenshot 2026-02-26 at 3 30 32 PM" src="https://github.com/user-attachments/assets/b039f548-867b-4f5c-9061-295510755c7f" />
<img width="1179" height="894" alt="Screenshot 2026-02-26 at 3 50 39 PM" src="https://github.com/user-attachments/assets/0ad6712d-d008-4e95-90ff-4981214d1e3d" />

Error in Idle Screen **(Please Note: for presets that have a logo, the logo will appear above the error)**

<img width="1105" height="941" alt="Screenshot 2026-03-04 at 10 22 01 AM" src="https://github.com/user-attachments/assets/6d4bd041-fecf-4db2-baf1-f2ee78e37806" />

