### PR TITLE
fix: move Meeting AI into rtk-sidebar and fix tab selection states

### DIFF
--- a/packages/angular-library/projects/components/src/lib/stencil-generated/components.ts
+++ b/packages/angular-library/projects/components/src/lib/stencil-generated/components.ts
@@ -22,19 +22,11 @@ export class RtkAi {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['rtkStateUpdate']);
   }
 }
 
 
-import type { States as IRtkAiStates } from '@cloudflare/realtimekit-ui';
-
-export declare interface RtkAi extends Components.RtkAi {
-  /**
-   * Emits updated state data
-   */
-  rtkStateUpdate: EventEmitter<CustomEvent<IRtkAiStates>>;
-}
+export declare interface RtkAi extends Components.RtkAi {}
 
 
 @ProxyCmp({

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -86,6 +86,11 @@ export { MeetingMode as MeetingMode1 } from "./components/rtk-meeting/rtk-meetin
 export { ViewerCountVariant } from "./components/rtk-viewer-count/rtk-viewer-count";
 export { Peer as Peer1 } from ".";
 export namespace Components {
+    /**
+     * An AI assistant component for meeting interactions.
+     * Provides AI-powered features like transcription, summarization, and
+     * intelligent meeting assistance. Rendered inside rtk-sidebar as the 'ai' section.
+     */
     interface RtkAi {
         /**
           * Config
@@ -391,6 +396,11 @@ export namespace Components {
          */
         "variant": ControlBarVariant;
     }
+    /**
+     * A modal for sending broadcast messages to all meeting participants.
+     * Allows hosts and moderators to send important announcements that
+     * appear prominently to all users in the meeting.
+     */
     interface RtkBroadcastMessageModal {
         /**
           * Icon pack
@@ -1600,6 +1610,10 @@ export namespace Components {
          */
         "meeting": Meeting;
         /**
+          * States object
+         */
+        "states": States;
+        /**
           * Language
          */
         "t": RtkI18n;
@@ -1787,6 +1801,11 @@ export namespace Components {
          */
         "t": RtkI18n1;
     }
+    /**
+     * A toggle button for starting/stopping livestream broadcasting.
+     * Only visible to users with livestream permissions. Allows hosts to
+     * broadcast the meeting to external streaming platforms.
+     */
     interface RtkLivestreamToggle {
         /**
           * Icon pack
@@ -2686,6 +2705,11 @@ export namespace Components {
          */
         "view": ParticipantsViewMode;
     }
+    /**
+     * A component that displays participants waiting in the stage queue.
+     * Shows users who are waiting to be promoted to the stage in meetings
+     * with stage functionality enabled.
+     */
     interface RtkParticipantsStageQueue {
         /**
           * Config
@@ -2842,6 +2866,11 @@ export namespace Components {
          */
         "t": RtkI18n;
     }
+    /**
+     * A toggle button for enabling/disabling Picture-in-Picture mode.
+     * Allows users to switch the video display to a floating window that stays
+     * on top of other applications.
+     */
     interface RtkPipToggle {
         /**
           * Config
@@ -3371,6 +3400,11 @@ export namespace Components {
          */
         "view": RtkSidebarView;
     }
+    /**
+     * A sidebar UI component with tabbed navigation.
+     * Provides a container for sidebar content with tab switching functionality.
+     * Can be displayed as a sidebar or in full-screen mode.
+     */
     interface RtkSidebarUi {
         /**
           * Default tab to open
@@ -3924,10 +3958,6 @@ export namespace Components {
         "t": RtkI18n;
     }
 }
-export interface RtkAiCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLRtkAiElement;
-}
 export interface RtkAiToggleCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLRtkAiToggleElement;
@@ -4233,18 +4263,12 @@ export interface RtkUiProviderCustomEvent<T> extends CustomEvent<T> {
     target: HTMLRtkUiProviderElement;
 }
 declare global {
-    interface HTMLRtkAiElementEventMap {
-        "rtkStateUpdate": States;
-    }
+    /**
+     * An AI assistant component for meeting interactions.
+     * Provides AI-powered features like transcription, summarization, and
+     * intelligent meeting assistance. Rendered inside rtk-sidebar as the 'ai' section.
+     */
     interface HTMLRtkAiElement extends Components.RtkAi, HTMLStencilElement {
-        addEventListener<K extends keyof HTMLRtkAiElementEventMap>(type: K, listener: (this: HTMLRtkAiElement, ev: RtkAiCustomEvent<HTMLRtkAiElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLRtkAiElementEventMap>(type: K, listener: (this: HTMLRtkAiElement, ev: RtkAiCustomEvent<HTMLRtkAiElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLRtkAiElement: {
         prototype: HTMLRtkAiElement;
@@ -4394,6 +4418,11 @@ declare global {
     interface HTMLRtkBroadcastMessageModalElementEventMap {
         "rtkStateUpdate": States1;
     }
+    /**
+     * A modal for sending broadcast messages to all meeting participants.
+     * Allows hosts and moderators to send important announcements that
+     * appear prominently to all users in the meeting.
+     */
     interface HTMLRtkBroadcastMessageModalElement extends Components.RtkBroadcastMessageModal, HTMLStencilElement {
         addEventListener<K extends keyof HTMLRtkBroadcastMessageModalElementEventMap>(type: K, listener: (this: HTMLRtkBroadcastMessageModalElement, ev: RtkBroadcastMessageModalCustomEvent<HTMLRtkBroadcastMessageModalElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5204,6 +5233,11 @@ declare global {
     message: string;
   };
     }
+    /**
+     * A toggle button for starting/stopping livestream broadcasting.
+     * Only visible to users with livestream permissions. Allows hosts to
+     * broadcast the meeting to external streaming platforms.
+     */
     interface HTMLRtkLivestreamToggleElement extends Components.RtkLivestreamToggle, HTMLStencilElement {
         addEventListener<K extends keyof HTMLRtkLivestreamToggleElementEventMap>(type: K, listener: (this: HTMLRtkLivestreamToggleElement, ev: RtkLivestreamToggleCustomEvent<HTMLRtkLivestreamToggleElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5609,6 +5643,11 @@ declare global {
         prototype: HTMLRtkParticipantsStageListElement;
         new (): HTMLRtkParticipantsStageListElement;
     };
+    /**
+     * A component that displays participants waiting in the stage queue.
+     * Shows users who are waiting to be promoted to the stage in meetings
+     * with stage functionality enabled.
+     */
     interface HTMLRtkParticipantsStageQueueElement extends Components.RtkParticipantsStageQueue, HTMLStencilElement {
     }
     var HTMLRtkParticipantsStageQueueElement: {
@@ -5693,6 +5732,11 @@ declare global {
     interface HTMLRtkPipToggleElementEventMap {
         "rtkStateUpdate": States1;
     }
+    /**
+     * A toggle button for enabling/disabling Picture-in-Picture mode.
+     * Allows users to switch the video display to a floating window that stays
+     * on top of other applications.
+     */
     interface HTMLRtkPipToggleElement extends Components.RtkPipToggle, HTMLStencilElement {
         addEventListener<K extends keyof HTMLRtkPipToggleElementEventMap>(type: K, listener: (this: HTMLRtkPipToggleElement, ev: RtkPipToggleCustomEvent<HTMLRtkPipToggleElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -6073,6 +6117,11 @@ declare global {
         "tabChange": string;
         "sidebarClose": void;
     }
+    /**
+     * A sidebar UI component with tabbed navigation.
+     * Provides a container for sidebar content with tab switching functionality.
+     * Can be displayed as a sidebar or in full-screen mode.
+     */
     interface HTMLRtkSidebarUiElement extends Components.RtkSidebarUi, HTMLStencilElement {
         addEventListener<K extends keyof HTMLRtkSidebarUiElementEventMap>(type: K, listener: (this: HTMLRtkSidebarUiElement, ev: RtkSidebarUiCustomEvent<HTMLRtkSidebarUiElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -6488,6 +6537,11 @@ declare global {
     }
 }
 declare namespace LocalJSX {
+    /**
+     * An AI assistant component for meeting interactions.
+     * Provides AI-powered features like transcription, summarization, and
+     * intelligent meeting assistance. Rendered inside rtk-sidebar as the 'ai' section.
+     */
     interface RtkAi {
         /**
           * Config
@@ -6501,10 +6555,6 @@ declare namespace LocalJSX {
           * Meeting object
          */
         "meeting"?: Meeting;
-        /**
-          * Emits updated state data
-         */
-        "onRtkStateUpdate"?: (event: RtkAiCustomEvent<States>) => void;
         /**
           * Size
          */
@@ -6846,6 +6896,11 @@ declare namespace LocalJSX {
          */
         "variant"?: ControlBarVariant;
     }
+    /**
+     * A modal for sending broadcast messages to all meeting participants.
+     * Allows hosts and moderators to send important announcements that
+     * appear prominently to all users in the meeting.
+     */
     interface RtkBroadcastMessageModal {
         /**
           * Icon pack
@@ -8210,6 +8265,10 @@ declare namespace LocalJSX {
          */
         "meeting"?: Meeting;
         /**
+          * States object
+         */
+        "states"?: States;
+        /**
           * Language
          */
         "t"?: RtkI18n;
@@ -8436,6 +8495,11 @@ declare namespace LocalJSX {
          */
         "t"?: RtkI18n1;
     }
+    /**
+     * A toggle button for starting/stopping livestream broadcasting.
+     * Only visible to users with livestream permissions. Allows hosts to
+     * broadcast the meeting to external streaming platforms.
+     */
     interface RtkLivestreamToggle {
         /**
           * Icon pack
@@ -9377,6 +9441,11 @@ declare namespace LocalJSX {
          */
         "view"?: ParticipantsViewMode;
     }
+    /**
+     * A component that displays participants waiting in the stage queue.
+     * Shows users who are waiting to be promoted to the stage in meetings
+     * with stage functionality enabled.
+     */
     interface RtkParticipantsStageQueue {
         /**
           * Config
@@ -9545,6 +9614,11 @@ declare namespace LocalJSX {
          */
         "t"?: RtkI18n;
     }
+    /**
+     * A toggle button for enabling/disabling Picture-in-Picture mode.
+     * Allows users to switch the video display to a floating window that stays
+     * on top of other applications.
+     */
     interface RtkPipToggle {
         /**
           * Config
@@ -10154,6 +10228,11 @@ declare namespace LocalJSX {
          */
         "view"?: RtkSidebarView;
     }
+    /**
+     * A sidebar UI component with tabbed navigation.
+     * Provides a container for sidebar content with tab switching functionality.
+     * Can be displayed as a sidebar or in full-screen mode.
+     */
     interface RtkSidebarUi {
         /**
           * Default tab to open
@@ -10888,6 +10967,11 @@ export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
+            /**
+             * An AI assistant component for meeting interactions.
+             * Provides AI-powered features like transcription, summarization, and
+             * intelligent meeting assistance. Rendered inside rtk-sidebar as the 'ai' section.
+             */
             "rtk-ai": LocalJSX.RtkAi & JSXBase.HTMLAttributes<HTMLRtkAiElement>;
             "rtk-ai-toggle": LocalJSX.RtkAiToggle & JSXBase.HTMLAttributes<HTMLRtkAiToggleElement>;
             "rtk-ai-transcriptions": LocalJSX.RtkAiTranscriptions & JSXBase.HTMLAttributes<HTMLRtkAiTranscriptionsElement>;
@@ -10914,6 +10998,11 @@ declare module "@stencil/core" {
              * You need to pass the `meeting` object to it.
              */
             "rtk-breakout-rooms-toggle": LocalJSX.RtkBreakoutRoomsToggle & JSXBase.HTMLAttributes<HTMLRtkBreakoutRoomsToggleElement>;
+            /**
+             * A modal for sending broadcast messages to all meeting participants.
+             * Allows hosts and moderators to send important announcements that
+             * appear prominently to all users in the meeting.
+             */
             "rtk-broadcast-message-modal": LocalJSX.RtkBroadcastMessageModal & JSXBase.HTMLAttributes<HTMLRtkBroadcastMessageModalElement>;
             /**
              * A button that follows RTK Design System.
@@ -11093,6 +11182,11 @@ declare module "@stencil/core" {
             "rtk-leave-meeting": LocalJSX.RtkLeaveMeeting & JSXBase.HTMLAttributes<HTMLRtkLeaveMeetingElement>;
             "rtk-livestream-indicator": LocalJSX.RtkLivestreamIndicator & JSXBase.HTMLAttributes<HTMLRtkLivestreamIndicatorElement>;
             "rtk-livestream-player": LocalJSX.RtkLivestreamPlayer & JSXBase.HTMLAttributes<HTMLRtkLivestreamPlayerElement>;
+            /**
+             * A toggle button for starting/stopping livestream broadcasting.
+             * Only visible to users with livestream permissions. Allows hosts to
+             * broadcast the meeting to external streaming platforms.
+             */
             "rtk-livestream-toggle": LocalJSX.RtkLivestreamToggle & JSXBase.HTMLAttributes<HTMLRtkLivestreamToggleElement>;
             /**
              * A component which loads the logo from your config, or via the `logo-url` attribute.
@@ -11209,6 +11303,11 @@ declare module "@stencil/core" {
              * run privileged actions on each participant according to your permissions.
              */
             "rtk-participants-stage-list": LocalJSX.RtkParticipantsStageList & JSXBase.HTMLAttributes<HTMLRtkParticipantsStageListElement>;
+            /**
+             * A component that displays participants waiting in the stage queue.
+             * Shows users who are waiting to be promoted to the stage in meetings
+             * with stage functionality enabled.
+             */
             "rtk-participants-stage-queue": LocalJSX.RtkParticipantsStageQueue & JSXBase.HTMLAttributes<HTMLRtkParticipantsStageQueueElement>;
             /**
              * A button which toggles visibility of participants.
@@ -11226,6 +11325,11 @@ declare module "@stencil/core" {
              */
             "rtk-permissions-message": LocalJSX.RtkPermissionsMessage & JSXBase.HTMLAttributes<HTMLRtkPermissionsMessageElement>;
             "rtk-pinned-message-selector": LocalJSX.RtkPinnedMessageSelector & JSXBase.HTMLAttributes<HTMLRtkPinnedMessageSelectorElement>;
+            /**
+             * A toggle button for enabling/disabling Picture-in-Picture mode.
+             * Allows users to switch the video display to a floating window that stays
+             * on top of other applications.
+             */
             "rtk-pip-toggle": LocalJSX.RtkPipToggle & JSXBase.HTMLAttributes<HTMLRtkPipToggleElement>;
             /**
              * A component which loads a plugin.
@@ -11336,6 +11440,11 @@ declare module "@stencil/core" {
              * you can customize which sections you want, and which section you want as the default.
              */
             "rtk-sidebar": LocalJSX.RtkSidebar & JSXBase.HTMLAttributes<HTMLRtkSidebarElement>;
+            /**
+             * A sidebar UI component with tabbed navigation.
+             * Provides a container for sidebar content with tab switching functionality.
+             * Can be displayed as a sidebar or in full-screen mode.
+             */
             "rtk-sidebar-ui": LocalJSX.RtkSidebarUi & JSXBase.HTMLAttributes<HTMLRtkSidebarUiElement>;
             /**
              * A grid component which renders only the participants in a simple grid.

--- a/packages/core/src/components/rtk-ai-toggle/rtk-ai-toggle.tsx
+++ b/packages/core/src/components/rtk-ai-toggle/rtk-ai-toggle.tsx
@@ -44,20 +44,26 @@ export class RtkAiToggle {
   /** Emits updated state data */
   @Event({ eventName: 'rtkStateUpdate' }) stateUpdate: EventEmitter<States>;
 
-  @Watch('states')
-  statesChanged(s?: States) {
-    const states = s;
-    this.aiActive = states.activeAI;
+  connectedCallback() {
+    this.statesChanged(this.states);
   }
 
-  private toggleAI() {
-    this.aiActive = !this.states?.activeAI;
-    this.stateUpdate.emit({
-      activeAI: this.aiActive,
-      activeMoreMenu: false,
-      activeSidebar: false,
-    });
+  @Watch('states')
+  statesChanged(states?: States) {
+    if (states != null) {
+      this.aiActive = states.activeSidebar === true && states.sidebar === 'ai';
+    }
   }
+
+  private toggleAI = () => {
+    const states = this.states;
+    this.aiActive = !(states?.activeSidebar && states?.sidebar === 'ai');
+    this.stateUpdate.emit({
+      activeSidebar: this.aiActive,
+      sidebar: this.aiActive ? 'ai' : undefined,
+      activeMoreMenu: false,
+    });
+  };
 
   render() {
     if (!this.meeting) return null;
@@ -74,7 +80,7 @@ export class RtkAiToggle {
           size={this.size}
           iconPack={this.iconPack}
           class={{ active: this.aiActive }}
-          onClick={() => this.toggleAI()}
+          onClick={this.toggleAI}
           icon={this.iconPack.meeting_ai}
           label={text}
           variant={this.variant}

--- a/packages/core/src/components/rtk-ai-transcriptions/rtk-ai-transcriptions.tsx
+++ b/packages/core/src/components/rtk-ai-transcriptions/rtk-ai-transcriptions.tsx
@@ -155,7 +155,7 @@ export class RtkAiTranscriptions {
         <div class="search-bar">
           <input
             type="text"
-            placeholder="Search Participant"
+            placeholder="Search participant"
             value={this.participantQuery}
             onInput={(e) => (this.participantQuery = (e.target as HTMLInputElement).value)}
           />

--- a/packages/core/src/components/rtk-ai/rtk-ai.tsx
+++ b/packages/core/src/components/rtk-ai/rtk-ai.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, Watch, Event, EventEmitter } from '@stencil/core';
+import { Component, Host, h, Prop } from '@stencil/core';
 import { Meeting } from '../../types/rtk-client';
 import type { Size, States } from '../../types/props';
 import { UIConfig } from '../../types/ui-config';
@@ -6,7 +6,6 @@ import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { createDefaultConfig } from '../../lib/default-ui-config';
 import { SyncWithStore } from '../../utils/sync-with-store';
-import { RTKPermissionsPreset } from '@cloudflare/realtimekit';
 
 export type AIView = 'default' | 'sidebar' | 'full-screen';
 
@@ -14,7 +13,7 @@ export type AIView = 'default' | 'sidebar' | 'full-screen';
  * An AI assistant component for meeting interactions.
  *
  * Provides AI-powered features like transcription, summarization, and
- * intelligent meeting assistance. Can be displayed in different view modes.
+ * intelligent meeting assistance. Rendered inside rtk-sidebar as the 'ai' section.
  */
 @Component({
   tag: 'rtk-ai',
@@ -22,8 +21,6 @@ export type AIView = 'default' | 'sidebar' | 'full-screen';
   shadow: true,
 })
 export class RtkAi {
-  private keydownListener: (e: KeyboardEvent) => void;
-
   /** Meeting object */
   @SyncWithStore()
   @Prop()
@@ -55,41 +52,8 @@ export class RtkAi {
   /** View type */
   @Prop({ reflect: true }) view: AIView = 'sidebar';
 
-  /** Emits updated state data */
-  @Event({ eventName: 'rtkStateUpdate' }) stateUpdate: EventEmitter<States>;
-
-  connectedCallback() {
-    this.viewChanged(this.view);
-  }
-
-  disconnectedCallback() {
-    this.keydownListener && document.removeEventListener('keydown', this.keydownListener);
-  }
-
-  @Watch('view')
-  viewChanged(view: AIView) {
-    if (view === 'full-screen') {
-      this.keydownListener = (e) => {
-        if (e.key === 'Escape') {
-          this.close();
-        }
-      };
-      document.addEventListener('keydown', this.keydownListener);
-    }
-  }
-
-  private close = () => {
-    this.stateUpdate.emit({ activeAI: false });
-  };
-
   render() {
     if (!this.meeting) return null;
-    if (
-      !(this.meeting?.self?.permissions as RTKPermissionsPreset).transcriptionEnabled ||
-      !this.states?.activeAI
-    ) {
-      return null;
-    }
 
     const defaults = {
       meeting: this.meeting,
@@ -102,20 +66,6 @@ export class RtkAi {
 
     return (
       <Host>
-        {/* Full screen view, shows the navigation header */}
-        <h3 class="title">{this.t('ai.transcriptions')}</h3>
-
-        {/* Close button */}
-        <rtk-button
-          variant="ghost"
-          kind="icon"
-          class="close"
-          onClick={this.close}
-          aria-label={this.t('close')}
-        >
-          <rtk-icon icon={this.iconPack.dismiss} />
-        </rtk-button>
-
         <rtk-ai-transcriptions {...defaults}></rtk-ai-transcriptions>
       </Host>
     );

--- a/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
+++ b/packages/core/src/components/rtk-chat-toggle/rtk-chat-toggle.tsx
@@ -118,7 +118,6 @@ export class RtkChatToggle {
       activeSidebar: this.chatActive,
       sidebar: this.chatActive ? 'chat' : undefined,
       activeMoreMenu: false,
-      activeAI: false,
     });
   };
 

--- a/packages/core/src/components/rtk-participants-toggle/rtk-participants-toggle.tsx
+++ b/packages/core/src/components/rtk-participants-toggle/rtk-participants-toggle.tsx
@@ -154,7 +154,6 @@ export class RtkParticipantsToggle {
       activeSidebar: this.participantsActive,
       sidebar: this.participantsActive ? 'participants' : undefined,
       activeMoreMenu: false,
-      activeAI: false,
     });
   }
 

--- a/packages/core/src/components/rtk-plugins-toggle/rtk-plugins-toggle.tsx
+++ b/packages/core/src/components/rtk-plugins-toggle/rtk-plugins-toggle.tsx
@@ -87,7 +87,6 @@ export class RtkPluginsToggle {
       activeSidebar: this.pluginsActive,
       sidebar: this.pluginsActive ? 'plugins' : undefined,
       activeMoreMenu: false,
-      activeAI: false,
     });
   }
 

--- a/packages/core/src/components/rtk-polls-toggle/rtk-polls-toggle.tsx
+++ b/packages/core/src/components/rtk-polls-toggle/rtk-polls-toggle.tsx
@@ -101,7 +101,6 @@ export class RtkPollsToggle {
       activeSidebar: this.pollsActive,
       sidebar: this.pollsActive ? 'polls' : undefined,
       activeMoreMenu: false,
-      activeAI: false,
     });
   }
 

--- a/packages/core/src/components/rtk-sidebar/rtk-sidebar.tsx
+++ b/packages/core/src/components/rtk-sidebar/rtk-sidebar.tsx
@@ -6,6 +6,7 @@ import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { createDefaultConfig } from '../../lib/default-ui-config';
 import {
+  canViewAI,
   canViewChat,
   canViewParticipants,
   canViewPlugins,
@@ -16,7 +17,7 @@ import { SyncWithStore } from '../../utils/sync-with-store';
 import { StageStatus } from '@cloudflare/realtimekit';
 import { Render } from '../../lib/render';
 
-export type RtkSidebarSection = 'chat' | 'polls' | 'participants' | 'plugins';
+export type RtkSidebarSection = 'chat' | 'polls' | 'participants' | 'plugins' | 'ai';
 
 /**
  * A component which handles the sidebar and
@@ -124,7 +125,9 @@ export class RtkSidebar {
     }
 
     return this.enabledSections.filter(
-      (section) => this.meeting.self.config.controlBar.elements[section.id]
+      (section) =>
+        !(section.id in this.meeting.self.config.controlBar.elements) ||
+        this.meeting.self.config.controlBar.elements[section.id]
     );
   };
 
@@ -150,6 +153,9 @@ export class RtkSidebar {
     }
     if (canViewPlugins(meeting)) {
       list.push({ id: 'plugins', name: this.t('plugins') });
+    }
+    if (canViewAI(meeting)) {
+      list.push({ id: 'ai', name: this.t('ai.meeting_ai') });
     }
     this.enabledSections = list;
   }
@@ -212,6 +218,7 @@ export class RtkSidebar {
             />
           )}
           {defaults.states.sidebar === 'plugins' && <rtk-plugins {...defaults} slot="plugins" />}
+          {defaults.states.sidebar === 'ai' && <rtk-ai {...defaults} slot="ai" />}
         </rtk-sidebar-ui>
       </Host>
     );

--- a/packages/core/src/lib/default-ui-config.ts
+++ b/packages/core/src/lib/default-ui-config.ts
@@ -147,7 +147,7 @@ export const defaultConfig: UIConfig = {
       // if using key value pair, provide the key in `state`
       // else provide array of states in `states`
       state: 'meeting',
-      states: ['activeSidebar', 'activeAI'],
+      states: ['activeSidebar'],
     },
     'rtk-meeting[meeting=waiting]': ['rtk-waiting-screen'],
     'rtk-meeting[meeting=idle]': ['rtk-idle-screen'],
@@ -165,13 +165,6 @@ export const defaultConfig: UIConfig = {
     'rtk-meeting[meeting=joined].activeSidebar.md': {
       add: [['rtk-sidebar', { view: 'full-screen' }]],
     },
-    'rtk-meeting[meeting=joined].activeAI.sm': {
-      add: [['rtk-ai', { view: 'full-screen' }]],
-    },
-    'rtk-meeting[meeting=joined].activeAI.md': {
-      add: [['rtk-ai', { view: 'full-screen' }]],
-    },
-
     'rtk-meeting[meeting=ended]': ['rtk-ended-screen'],
 
     'rtk-header': ['div#header-left', 'div#header-center', 'div#header-right'],
@@ -193,7 +186,7 @@ export const defaultConfig: UIConfig = {
     ],
 
     'rtk-stage': {
-      states: ['activeSidebar', 'activeAI'],
+      states: ['activeSidebar'],
       children: ['rtk-grid', 'rtk-notifications', 'rtk-transcripts'],
     },
 
@@ -203,13 +196,6 @@ export const defaultConfig: UIConfig = {
 
     // hide sidebar for smaller screens
     'rtk-stage.activeSidebar.sm': { remove: ['rtk-sidebar'] },
-
-    'rtk-stage.activeAI': {
-      add: [['rtk-ai', { view: 'sidebar' }]],
-    },
-
-    // hide sidebar for smaller screens
-    'rtk-stage.activeAI.sm': { remove: ['rtk-ai'] },
 
     'rtk-grid': {
       states: ['activeScreenShare', 'activePlugin', 'activeSpotlight'],

--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -370,7 +370,7 @@ export const generateConfig = (
         // if using key value pair, provide the key in `state`
         // else provide array of states in `states`
         state: 'meeting',
-        states: ['activeSidebar', 'activeAI'],
+        states: ['activeSidebar'],
       },
       'rtk-meeting[meeting=idle]': ['rtk-idle-screen'],
       'rtk-meeting[meeting=waiting]': ['rtk-waiting-screen'],
@@ -382,19 +382,13 @@ export const generateConfig = (
       'rtk-meeting[meeting=joined].activeSidebar.md': {
         add: [['rtk-sidebar', { view: 'full-screen' }]],
       },
-      'rtk-meeting[meeting=joined].activeAI.sm': {
-        add: [['rtk-ai', { view: 'full-screen' }]],
-      },
-      'rtk-meeting[meeting=joined].activeAI.md': {
-        add: [['rtk-ai', { view: 'full-screen' }]],
-      },
       'rtk-meeting[meeting=ended]': ['rtk-ended-screen'],
 
       ...headerChildren,
       ...controlBarChildren,
 
       'rtk-stage': {
-        states: ['activeSidebar', 'activeAI'],
+        states: ['activeSidebar'],
         children: ['rtk-grid', 'rtk-notifications', 'rtk-transcripts'],
       },
 
@@ -404,13 +398,6 @@ export const generateConfig = (
 
       // hide sidebar for smaller screens
       'rtk-stage.activeSidebar.sm': { remove: ['rtk-sidebar'] },
-
-      'rtk-stage.activeAI': {
-        add: [['rtk-ai', { view: 'sidebar' }]],
-      },
-
-      // hide sidebar for smaller screens
-      'rtk-stage.activeAI.sm': { remove: ['rtk-ai'] },
 
       'rtk-grid': {
         states: ['activeScreenShare', 'activePlugin', 'activeSpotlight'],

--- a/packages/core/src/utils/sidebar.ts
+++ b/packages/core/src/utils/sidebar.ts
@@ -35,6 +35,10 @@ export const canViewParticipants = (meeting: Meeting) => {
   return true;
 };
 
+export const canViewAI = (meeting: Meeting) => {
+  return !!(meeting?.self?.permissions as any)?.transcriptionEnabled;
+};
+
 export const canViewPlugins = (meeting: Meeting) => {
   if (isLiveStreamViewer(meeting)) return false;
   if (meeting && !meeting.plugins) return false;


### PR DESCRIPTION
https://jira.cfdata.org/browse/RTK-7711

### Description
Meeting AI was originally implemented as a separate component, although visually it sits next to chat, polls, participants, plugins. The latter 4 are part of the  rtk-siddebar, and as such  don't require any specific management of selection statees.  Moving the Meeting AI into the rtl-sidebar will fix this for the interaction of selections states between meeting ai and the other tabs.



### Screenshots

Before:

https://github.com/user-attachments/assets/a6e8e42d-ae51-44cf-b9b5-4e9b28d28caf



After: 

https://github.com/user-attachments/assets/8398dc2c-06a2-4489-9c96-7552c83b924b


