### PR TITLE
refactor(utils): rename exitFullSreen to exitFullScreen to fix typo

### DIFF
--- a/packages/core/src/components/rtk-fullscreen-toggle/rtk-fullscreen-toggle.tsx
+++ b/packages/core/src/components/rtk-fullscreen-toggle/rtk-fullscreen-toggle.tsx
@@ -3,7 +3,7 @@ import { defaultIconPack, IconPack } from '../../lib/icons';
 import { RtkI18n, useLanguage } from '../../lib/lang';
 import { Size, States } from '../../types/props';
 import {
-  exitFullSreen,
+  exitFullScreen,
   isFullScreenEnabled,
   isFullScreenSupported,
   requestFullScreen,
@@ -75,7 +75,7 @@ export class RtkFullscreenToggle {
       requestFullScreen(fullScreenElement);
       this.fullScreenActive = true;
     } else {
-      exitFullSreen();
+      exitFullScreen();
       this.fullScreenActive = false;
     }
     this.stateUpdate.emit({ activeMoreMenu: false });

--- a/packages/core/src/components/rtk-screenshare-view/rtk-screenshare-view.tsx
+++ b/packages/core/src/components/rtk-screenshare-view/rtk-screenshare-view.tsx
@@ -15,7 +15,7 @@ import { RtkI18n, useLanguage } from '../../lib/lang';
 import { Meeting, Peer } from '../../types/rtk-client';
 import { Size, States } from '../../types/props';
 import {
-  exitFullSreen,
+  exitFullScreen,
   isFullScreenEnabled,
   isFullScreenSupported,
   requestFullScreen,
@@ -172,7 +172,7 @@ export class RtkScreenshareView {
       requestFullScreen(this.host);
       this.isFullScreen = true;
     } else {
-      exitFullSreen();
+      exitFullScreen();
       this.isFullScreen = false;
     }
   };

--- a/packages/core/src/utils/full-screen.ts
+++ b/packages/core/src/utils/full-screen.ts
@@ -15,7 +15,7 @@ export const requestFullScreen = (el: HTMLElement) => {
   }
 };
 
-export const exitFullSreen = () => {
+export const exitFullScreen = () => {
   if (document.exitFullscreen != null) {
     document.exitFullscreen();
   } else if (document.mozExitFullScreen != null) {


### PR DESCRIPTION
This PR fixes a method name typo in the full-screen utils: `exitFullSreen`  -> `exitFullScreen` 
