### PR TITLE
ci: add Bonk AI review workflow for pull requests

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -1,0 +1,62 @@
+name: Bonk-AI PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review:
+    # Guard 1: Skip fork PRs — the workflow should only review internal PRs.
+    # Guard 2: Skip release PRs (staging -> main) — already reviewed individually.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+      && !(github.event.pull_request.head.ref == 'staging'
+        && github.event.pull_request.base.ref == 'main')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+      # Don't cancel in-progress reviews — a partial review can leave
+      # orphaned comments and wastes AI API credits.
+      cancel-in-progress: false
+    permissions:
+      id-token: write
+      # 'read' access to prevent the agent from self-modifying files.
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Bonk
+        uses: ask-bonk/ask-bonk/github@main
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
+          CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
+        with:
+          model: 'cloudflare-ai-gateway/anthropic/claude-opus-4-6'
+          forks: 'false'
+          permissions: write
+          opencode_version: '1.2.27'
+          # The auto-reviewer must never push to PR branches. NO_PUSH
+          # enforces contents: read at the token level so it holds even
+          # if the model ignores prompt instructions.
+          token_permissions: 'NO_PUSH'
+          prompt: |
+            Review this PR for bugs, security issues, performance problems, and style.
+            Read the full file for context, not just the diff.
+
+            Use the gh CLI to submit a single batch review via the GitHub API with
+            inline comments on specific files and line numbers. Use code suggestions
+            where you have high confidence in the fix — ensure they account for
+            surrounding code (braces, indentation, comments).
+
+            Separate "Needs Fix" (bugs, type errors, broken conventions, security)
+            from "Suggestions" (style, minor improvements, maintenance guidance).
+            Flag only medium and high priority issues — skip formatting the linter
+            handles, pre-existing issues, and hypothetical edge cases.
+            If the PR is clean, respond with only "LGTM!" and nothing else.
+
+            Leave the final review body empty — OpenCode posts the summary for you.

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -1,0 +1,21 @@
+# Required by Bonk's setup check — the backend verifies that a file at
+# exactly this path (.github/workflows/bonk.yml) exists on the default
+# branch before any Bonk workflow can run.
+# See: https://github.com/ask-bonk/ask-bonk/blob/main/src/workflow.ts
+#
+# This is a no-op placeholder. The actual review logic lives in
+# ai-pr-review.yml. If the team later wants interactive /bonk mentions,
+# replace this with a real comment-triggered workflow.
+name: Bonk
+
+on:
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  placeholder:
+    if: false
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'true'


### PR DESCRIPTION
Adds automated PR review using  Bonk-AI (https://github.com/ask-bonk/ask-bonk) by referring to the `workerd` team's setup (https://github.com/cloudflare/workerd/blob/main/.github/workflows/new-pr-review.yml).

Two workflow files added:

1. `ai-pr-review.yml` :- Auto-reviews new PRs on open, synchronize, and reopen events.
- Uses Cloudflare AI Gateway with `claude-opus-4-6`
- Skips release PRs (`staging` -> `main`) and fork PRs
- Scoped to `NO_PUSH` with `contents: read` to prevent the agent from self-modifying workflow files
- Gated to users with `write` permission
- Includes concurrency group and 30-min timeout
- Pins `opencode_version` to `1.2.27` for stability
 
2. `bonk.yml` :- No-op placeholder required by Bonk's setup check (https://github.com/ask-bonk/ask-bonk/blob/main/src/workflow.ts). The backend verifies this exact file exists on the default branch before any Bonk workflow can run. Can be replaced with a real comment-triggered workflow if the team wants `/bonk` mentions later.

closes: RTK-7806
