### PR TITLE
[RTK-7997] Add troubleshoot link on join failure screens

### DIFF
--- a/packages/core/src/components/rtk-idle-screen/rtk-idle-screen.css
+++ b/packages/core/src/components/rtk-idle-screen/rtk-idle-screen.css
@@ -17,6 +17,14 @@
   }
 }
 
+.error-state {
+  @apply flex w-full flex-col items-center;
+}
+
+.troubleshoot-link {
+  @apply text-brand-400 hover:text-brand-300 text-text-sm mt-1 underline underline-offset-2;
+}
+
 rtk-logo.loaded {
   @apply h-12;
 }

--- a/packages/core/src/components/rtk-idle-screen/rtk-idle-screen.tsx
+++ b/packages/core/src/components/rtk-idle-screen/rtk-idle-screen.tsx
@@ -96,14 +96,26 @@ export class RtkIdleScreen {
           <div class="ctr" part="container">
             <rtk-logo meeting={this.meeting} config={this.config} t={this.t} part="logo" />
             {this.joinError || showSocketError ? (
-              <div class="no-network-badge" part="network-badge">
-                <rtk-icon
-                  size="md"
-                  variant="danger"
-                  icon={this.iconPack.disconnected}
-                  part="network-badge-icon"
-                ></rtk-icon>
-                {errorText}
+              <div class="error-state">
+                <div class="no-network-badge" part="network-badge">
+                  <rtk-icon
+                    size="md"
+                    variant="danger"
+                    icon={this.iconPack.disconnected}
+                    part="network-badge-icon"
+                  ></rtk-icon>
+                  {errorText}
+                </div>
+                {this.meeting && this.joinError && (
+                  <a
+                    class="troubleshoot-link"
+                    href={`https://test.realtime.cloudflare.com?authToken=${this.meeting.__internals__.authToken}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {this.t('network.troubleshoot')}
+                  </a>
+                )}
               </div>
             ) : (
               <rtk-spinner

--- a/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.css
+++ b/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.css
@@ -84,3 +84,7 @@ rtk-participant-tile {
     @apply mx-2;
   }
 }
+
+.troubleshoot-link {
+  @apply text-brand-400 hover:text-brand-300 text-text-sm mt-1 underline underline-offset-2;
+}

--- a/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.tsx
+++ b/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.tsx
@@ -218,6 +218,16 @@ export class RtkSetupScreen {
                 {errorText}
               </div>
             )}
+            {this.meeting && this.joinError && (
+              <a
+                class="troubleshoot-link"
+                href={`https://test.realtime.cloudflare.com?authToken=${this.meeting.__internals__.authToken}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {this.t('network.troubleshoot')}
+              </a>
+            )}
           </div>
         </div>
       </Host>

--- a/packages/core/src/lib/lang/default-language.ts
+++ b/packages/core/src/lib/lang/default-language.ts
@@ -290,6 +290,7 @@ export const defaultLanguage = {
   'network.delay': 'Taking too long to reconnect.',
   'network.lost': 'Connection lost',
   'network.lost_extended': 'Connection lost. Please check your network connection.',
+  'network.troubleshoot': 'Troubleshoot your connection',
 
   livestream: 'Livestream',
   'livestream.indicator': 'This meeting is being livestreamed.',


### PR DESCRIPTION
⚠️  Needs `realtimekit` version **1.4.0** to land in staging.

### Description
- When join fails, show a "Troubleshoot your connection" link below the error badge
  on both `rtk-idle-screen` and `rtk-setup-screen`
- Link opens `https://test.realtime.cloudflare.com?authToken=<token>` in a new tab
- Link text is localized via `default-language.ts`

#### Visibility conditions
The troubleshoot link appears **only** when:
- `joinError` is set (definitive join failure) — not for transient socket reconnection states
- `meeting` object is available (needed for `meeting.__internals__.authToken`)

Does **not** appear on: ended screen, waiting room, permission errors, or normal meeting state.

### Screenshots

<img width="1158" height="615" alt="image" src="https://github.com/user-attachments/assets/d8211a14-be25-435f-a7bd-7f465af40929" />

</br>
completes: RTK-7997
