### PR TITLE
[RTK-8047] fix: replace raw SDK error messages with user-friendly messages on join failures

### DIFF
--- a/packages/core/src/components/rtk-idle-screen/rtk-idle-screen.css
+++ b/packages/core/src/components/rtk-idle-screen/rtk-idle-screen.css
@@ -25,6 +25,10 @@
   @apply text-brand-400 hover:text-brand-300 text-text-sm mt-1 underline underline-offset-2;
 }
 
+.error-code {
+  @apply text-text-xs text-text-600 mt-1;
+}
+
 rtk-logo.loaded {
   @apply h-12;
 }

--- a/packages/core/src/components/rtk-idle-screen/rtk-idle-screen.tsx
+++ b/packages/core/src/components/rtk-idle-screen/rtk-idle-screen.tsx
@@ -45,6 +45,8 @@ export class RtkIdleScreen {
 
   @State() joinError: string | undefined;
 
+  @State() joinErrorCode: string | undefined;
+
   @State() connectionState: SocketConnectionState['state'];
 
   connectedCallback() {
@@ -71,6 +73,7 @@ export class RtkIdleScreen {
     if (state === 'connected') {
       if (!this.states?.joinError) {
         this.joinError = undefined;
+        this.joinErrorCode = undefined;
       }
     }
   };
@@ -78,6 +81,7 @@ export class RtkIdleScreen {
   @Watch('states')
   statesChanged(states: States) {
     this.joinError = states?.joinError;
+    this.joinErrorCode = states?.joinErrorCode;
   }
 
   render() {
@@ -97,7 +101,7 @@ export class RtkIdleScreen {
             <rtk-logo meeting={this.meeting} config={this.config} t={this.t} part="logo" />
             {this.joinError || showSocketError ? (
               <div class="error-state">
-                <div class="no-network-badge" part="network-badge">
+                <div class="no-network-badge" part="network-badge" role="alert">
                   <rtk-icon
                     size="md"
                     variant="danger"
@@ -115,6 +119,11 @@ export class RtkIdleScreen {
                   >
                     {this.t('network.troubleshoot')}
                   </a>
+                )}
+                {this.joinErrorCode && (
+                  <span class="error-code" part="error-code">
+                    {this.t('join.error_code')}: {this.joinErrorCode}
+                  </span>
                 )}
               </div>
             ) : (

--- a/packages/core/src/components/rtk-meeting/rtk-meeting.tsx
+++ b/packages/core/src/components/rtk-meeting/rtk-meeting.tsx
@@ -18,6 +18,7 @@ import {
   type RtkUiStoreExtended,
 } from '../../utils/sync-with-store/ui-store';
 import { Overrides, defaultOverrides } from '../../lib/overrides';
+import { getJoinErrorInfo } from '../../utils/join-error';
 
 export type MeetingMode = 'fixed' | 'fill';
 
@@ -42,7 +43,7 @@ export class RtkMeeting {
   private providerId: string = 'provider-' + Math.floor(Math.random() * 100);
 
   private roomJoinedListener = () => {
-    this.updateStates({ meeting: 'joined', joinError: undefined });
+    this.updateStates({ meeting: 'joined', joinError: undefined, joinErrorCode: undefined });
   };
 
   private waitlistedListener = () => {
@@ -320,11 +321,11 @@ export class RtkMeeting {
         meeting
           .joinRoom()
           .then(() => {
-            this.updateStates({ joinError: undefined });
+            this.updateStates({ joinError: undefined, joinErrorCode: undefined });
           })
           .catch((err) => {
-            const message = err?.message ? err.message : this.t('network.lost_extended');
-            this.updateStates({ joinError: message });
+            const { message, code } = getJoinErrorInfo(this.t, err);
+            this.updateStates({ joinError: message, joinErrorCode: code });
           });
       }
     }

--- a/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.css
+++ b/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.css
@@ -88,3 +88,7 @@ rtk-participant-tile {
 .troubleshoot-link {
   @apply text-brand-400 hover:text-brand-300 text-text-sm mt-1 underline underline-offset-2;
 }
+
+.error-code {
+  @apply text-text-xs text-text-600 mt-1;
+}

--- a/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.tsx
+++ b/packages/core/src/components/rtk-setup-screen/rtk-setup-screen.tsx
@@ -20,6 +20,7 @@ import { RtkI18n, useLanguage } from '../../lib/lang';
 import gracefulStorage from '../../utils/graceful-storage';
 import { SyncWithStore } from '../../utils/sync-with-store';
 import { SocketConnectionState } from '@cloudflare/realtimekit';
+import { getJoinErrorInfo } from '../../utils/join-error';
 
 /**
  * A screen shown before joining the meeting, where you can edit your display name,
@@ -69,6 +70,8 @@ export class RtkSetupScreen {
 
   @State() joinError?: string;
 
+  @State() joinErrorCode?: string;
+
   @State() canEditName: boolean = true;
 
   @State() canProduceAudio: boolean = true;
@@ -101,6 +104,7 @@ export class RtkSetupScreen {
     this.connectionState = state;
     if (state === 'connected') {
       this.joinError = undefined;
+      this.joinErrorCode = undefined;
     }
     if (state === 'failed') this.isJoining = false;
   };
@@ -119,6 +123,7 @@ export class RtkSetupScreen {
 
       this.isJoining = true;
       this.joinError = undefined;
+      this.joinErrorCode = undefined;
       this.meeting?.self.setName(this.displayName);
 
       gracefulStorage.setItem('rtk-display-name', this.displayName);
@@ -126,7 +131,9 @@ export class RtkSetupScreen {
         await this.meeting?.joinRoom();
       } catch (e) {
         this.isJoining = false;
-        this.joinError = e?.message ? e.message : this.t('network.lost_extended');
+        const { message, code } = getJoinErrorInfo(this.t, e);
+        this.joinError = message;
+        this.joinErrorCode = code;
       }
     }
   };
@@ -213,7 +220,7 @@ export class RtkSetupScreen {
             </rtk-button>
 
             {(this.joinError || showSocketError) && (
-              <div class="no-network-badge">
+              <div class="no-network-badge" role="alert">
                 <rtk-icon size="md" variant="danger" icon={this.iconPack.disconnected}></rtk-icon>
                 {errorText}
               </div>
@@ -227,6 +234,11 @@ export class RtkSetupScreen {
               >
                 {this.t('network.troubleshoot')}
               </a>
+            )}
+            {this.joinErrorCode && (
+              <span class="error-code" part="error-code">
+                {this.t('join.error_code')}: {this.joinErrorCode}
+              </span>
             )}
           </div>
         </div>

--- a/packages/core/src/lib/lang/default-language.ts
+++ b/packages/core/src/lib/lang/default-language.ts
@@ -292,6 +292,15 @@ export const defaultLanguage = {
   'network.lost_extended': 'Connection lost. Please check your network connection.',
   'network.troubleshoot': 'Troubleshoot your connection',
 
+  'join.network_error':
+    "We couldn't connect to the meeting. Please check your internet connection and try again.",
+  'join.media_error':
+    "We're having trouble connecting to the meeting. Please try again, and if the problem continues, try using a different network.",
+  'join.media_firewall_error':
+    'Your network may be blocking this connection. Try using a different network, or contact your network administrator for help.',
+  'join.default_error': 'Something went wrong while joining the meeting. Please try again.',
+  'join.error_code': 'Error code',
+
   livestream: 'Livestream',
   'livestream.indicator': 'This meeting is being livestreamed.',
   'livestream.skip': 'Skip to Live',

--- a/packages/core/src/types/props.ts
+++ b/packages/core/src/types/props.ts
@@ -82,6 +82,7 @@ export interface States {
   sidebar?: RtkSidebarSection;
   roomLeftState?: RoomLeftState | 'unauthorized';
   joinError?: string;
+  joinErrorCode?: string;
   sidebarFloating?: boolean;
   participantsTabId?: ParticipantsTabId;
   [state: string]: any;

--- a/packages/core/src/utils/join-error.ts
+++ b/packages/core/src/utils/join-error.ts
@@ -1,0 +1,43 @@
+import { RtkI18n } from '../lib/lang';
+
+export interface JoinErrorInfo {
+  /** Localized, user-friendly message suitable for display to end users. */
+  message: string;
+  /**
+   * Raw SDK error code (e.g. '0002'), used for support reference display.
+   * Undefined when the caught value is not a ClientError (no code available).
+   */
+  code: string | undefined;
+}
+
+/**
+ * Maps a caught joinRoom() error to a user-friendly message and a support reference code.
+ *
+ * Use `err.code` as the primary branch — error codes are the stable SDK contract.
+ * The secondary `err.message` check for '0014' is intentional: the SDK sets a distinct
+ * message ('A firewall or network restriction may be blocking the connection.') for the
+ * ICE failure sub-case, which requires different user advice than a generic media failure.
+ *
+ * Only codes '0002' and '0014' are thrown by Client.join() today. The default branch
+ * handles any unknown or future codes gracefully.
+ */
+export function getJoinErrorInfo(t: RtkI18n, err: unknown): JoinErrorInfo {
+  const code: string | undefined = (err as any)?.code;
+
+  switch (code) {
+    case '0002':
+      return { message: t('join.network_error'), code };
+
+    case '0014': {
+      const isFirewall =
+        typeof (err as any)?.message === 'string' && (err as any).message.includes('firewall');
+      return {
+        message: isFirewall ? t('join.media_firewall_error') : t('join.media_error'),
+        code,
+      };
+    }
+
+    default:
+      return { message: t('join.default_error'), code };
+  }
+}


### PR DESCRIPTION
## Summary
- Replace raw SDK error messages (e.g. `[ERR0002]: {Client} Failed to join room.`) with user-friendly, localized messages when `joinRoom()` fails
- Show a small error reference code (`Error code: 0002`) for support/debugging purposes
- Add `role="alert"` to error badges for screen reader accessibility

Closes RTK-8047

### Screenshots
<img width="1158" height="615" alt="image" src="https://github.com/user-attachments/assets/a6c2dadc-ca49-4c44-8105-8ba13d1aa516" />


#### New: `utils/join-error.ts`
Centralized mapping from SDK error code → localized user message. Branches on `err.code` (stable SDK contract), not `err.message`.

| Code | Condition | User sees |
|------|-----------|-----------|
| `0002` | Socket/network failure | "We couldn't connect to the meeting. Please check your internet connection and try again." |
| `0014` | Media failure (generic) | "We're having trouble connecting to the meeting. Please try again, and if the problem continues, try using a different network." |
| `0014` | Media failure (firewall/ICE) | "Your network may be blocking this connection. Try using a different network, or contact your network administrator for help." |
| any other | Unknown/unexpected | "Something went wrong while joining the meeting. Please try again." |

#### Updated: error display
- **`rtk-idle-screen.tsx`** and **`rtk-setup-screen.tsx`** — render `Error code: 0002` in small muted text below the troubleshoot link, with `part="error-code"` for consumer CSS customization
- Error badges now have `role="alert"` for screen reader announcement
 
#### Updated: i18n
5 new keys under `join.*` namespace in `default-language.ts`. Overridable via language packs.

#### Updated: types
`joinErrorCode?: string` added to `States` interface (alongside existing `joinError`) to transport the code from `rtk-meeting`'s catch site to `rtk-idle-screen`'s render site.

