### PR TITLE
fix(release-pipeline): picking correct types from compatible realtimekit version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1059,9 +1059,9 @@
       "license": "MIT"
     },
     "node_modules/@cloudflare/realtimekit": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@cloudflare/realtimekit/-/realtimekit-1.2.4.tgz",
-      "integrity": "sha512-qsihYdepdtCmCnPDfAp+ceZBjn4ZzGxsvCk7t6vEjEwwjDsDAAj4AkbOyfu4nWorfaWx4dbPkWxynoYy/70gMQ==",
+      "version": "1.5.0-staging.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/realtimekit/-/realtimekit-1.5.0-staging.4.tgz",
+      "integrity": "sha512-F9lSLYZW0tdSeoe126AwmErUWH12RRSAM/RO1RLunkefwlXdV4/vuob8Xs1JXhxADXJdsgvj5YgF8VMBM9kSQw==",
       "dev": true,
       "dependencies": {
         "@protobuf-ts/runtime": "^2.7.0",
@@ -30686,7 +30686,7 @@
         "resize-observer-polyfill": "^1.5.1"
       },
       "devDependencies": {
-        "@cloudflare/realtimekit": "^1.2.4",
+        "@cloudflare/realtimekit": "^1.5.0-staging.4",
         "@rollup/plugin-commonjs": "^28.0.2",
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@rollup/plugin-terser": "^0.4.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,7 @@
     "resize-observer-polyfill": "^1.5.1"
   },
   "devDependencies": {
-    "@cloudflare/realtimekit": "^1.2.4",
+    "@cloudflare/realtimekit": "^1.5.0-staging.4",
     "@rollup/plugin-commonjs": "^28.0.2",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@rollup/plugin-terser": "^0.4.4",


### PR DESCRIPTION
### Description

Due to the introduction of authToken on meeting.__internals__, ui-kit was failing to build with types from older SDK version. Using SDK version for now, to fix the build. Post the production release, we will update this staging version to prod one. 

<img width="746" height="427" alt="image" src="https://github.com/user-attachments/assets/8cd0d7f3-0537-49ab-80c5-8670aba6bc15" />
