### PR TITLE
[RTK-8037] fix: handle init errors on idle screen instead of showing infinite spinner

### DIFF
--- a/packages/core/src/components/rtk-idle-screen/rtk-idle-screen.tsx
+++ b/packages/core/src/components/rtk-idle-screen/rtk-idle-screen.tsx
@@ -6,7 +6,7 @@ import { UIConfig } from '../../types/ui-config';
 import { SyncWithStore } from '../../utils/sync-with-store';
 import { Meeting } from '../../types/rtk-client';
 import { SocketConnectionState } from '@cloudflare/realtimekit';
-import { States } from '../../types/props';
+import { States, PreJoinError } from '../../types/props';
 
 /**
  * A screen that handles the idle state,
@@ -43,9 +43,7 @@ export class RtkIdleScreen {
   @Prop()
   t: RtkI18n = useLanguage();
 
-  @State() joinError: string | undefined;
-
-  @State() joinErrorCode: string | undefined;
+  @State() preJoinError: PreJoinError | null | undefined;
 
   @State() connectionState: SocketConnectionState['state'];
 
@@ -71,25 +69,26 @@ export class RtkIdleScreen {
   private socketStateUpdate = ({ state }: SocketConnectionState) => {
     this.connectionState = state;
     if (state === 'connected') {
-      if (!this.states?.joinError) {
-        this.joinError = undefined;
-        this.joinErrorCode = undefined;
+      if (!this.states?.preJoinError) {
+        this.preJoinError = undefined;
       }
     }
   };
 
   @Watch('states')
   statesChanged(states: States) {
-    this.joinError = states?.joinError;
-    this.joinErrorCode = states?.joinErrorCode;
+    this.preJoinError = states?.preJoinError;
   }
 
   render() {
-    const showSocketError =
-      !!this.connectionState && this.connectionState !== 'connected' && !this.joinError;
+    const errorMessage = this.preJoinError?.message;
+    const errorCode = this.preJoinError?.code;
 
-    const errorText = this.joinError
-      ? this.joinError
+    const showSocketError =
+      !!this.connectionState && this.connectionState !== 'connected' && !errorMessage;
+
+    const errorText = errorMessage
+      ? errorMessage
       : this.connectionState === 'failed'
       ? this.t('network.lost_extended')
       : this.t('network.lost');
@@ -99,7 +98,7 @@ export class RtkIdleScreen {
         <slot>
           <div class="ctr" part="container">
             <rtk-logo meeting={this.meeting} config={this.config} t={this.t} part="logo" />
-            {this.joinError || showSocketError ? (
+            {errorMessage || showSocketError ? (
               <div class="error-state">
                 <div class="no-network-badge" part="network-badge" role="alert">
                   <rtk-icon
@@ -110,7 +109,7 @@ export class RtkIdleScreen {
                   ></rtk-icon>
                   {errorText}
                 </div>
-                {this.meeting && this.joinError && (
+                {this.meeting && errorMessage && (
                   <a
                     class="troubleshoot-link"
                     href={`https://test.realtime.cloudflare.com?authToken=${this.meeting.__internals__.authToken}`}
@@ -120,9 +119,9 @@ export class RtkIdleScreen {
                     {this.t('network.troubleshoot')}
                   </a>
                 )}
-                {this.joinErrorCode && (
+                {errorCode && (
                   <span class="error-code" part="error-code">
-                    {this.t('join.error_code')}: {this.joinErrorCode}
+                    {this.t('join.error_code')}: {errorCode}
                   </span>
                 )}
               </div>

--- a/packages/core/src/components/rtk-meeting/rtk-meeting.tsx
+++ b/packages/core/src/components/rtk-meeting/rtk-meeting.tsx
@@ -18,6 +18,7 @@ import {
   type RtkUiStoreExtended,
 } from '../../utils/sync-with-store/ui-store';
 import { Overrides, defaultOverrides } from '../../lib/overrides';
+import { getInitErrorInfo } from '../../utils/init-error';
 import { getJoinErrorInfo } from '../../utils/join-error';
 
 export type MeetingMode = 'fixed' | 'fill';
@@ -43,7 +44,7 @@ export class RtkMeeting {
   private providerId: string = 'provider-' + Math.floor(Math.random() * 100);
 
   private roomJoinedListener = () => {
-    this.updateStates({ meeting: 'joined', joinError: undefined, joinErrorCode: undefined });
+    this.updateStates({ meeting: 'joined', preJoinError: null });
   };
 
   private waitlistedListener = () => {
@@ -131,16 +132,15 @@ export class RtkMeeting {
    */
   @Event({ eventName: 'rtkStatesUpdate' }) statesUpdate: EventEmitter<States>;
 
-  private authErrorListener: (ev: CustomEvent<Error>) => void;
+  private initErrorListener: (ev: CustomEvent) => void;
 
   connectedCallback() {
     if (typeof window !== 'undefined') {
-      this.authErrorListener = (ev) => {
-        if (ev.detail.message.includes('401')) {
-          this.updateStates({ meeting: 'ended', roomLeftState: 'unauthorized' });
-        }
+      this.initErrorListener = (ev) => {
+        const { message, code } = getInitErrorInfo(this.t, ev.detail);
+        this.updateStates({ preJoinError: { message, code } });
       };
-      window.addEventListener('rtkError', this.authErrorListener);
+      window.addEventListener('ClientError', this.initErrorListener);
     }
 
     // Initialize default values
@@ -175,7 +175,7 @@ export class RtkMeeting {
       this.meeting?.leave();
     }
     this.resizeObserver.disconnect();
-    window.removeEventListener('rtkError', this.authErrorListener);
+    window.removeEventListener('ClientError', this.initErrorListener);
 
     // Remove event listeners
     if (this.storeRequestListener) {
@@ -323,16 +323,16 @@ export class RtkMeeting {
         meeting
           .join()
           .then(() => {
-            this.updateStates({ joinError: undefined, joinErrorCode: undefined });
+            this.updateStates({ preJoinError: null });
           })
           .catch((err) => {
             const { message, code } = getJoinErrorInfo(this.t, err);
-            this.updateStates({ joinError: message, joinErrorCode: code });
+            this.updateStates({ preJoinError: { message, code } });
           });
       }
     }
 
-    window.removeEventListener('rtkError', this.authErrorListener);
+    window.removeEventListener('ClientError', this.initErrorListener);
   }
 
   private handleChangingMeeting = (destinationMeetingId: string) => {

--- a/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
+++ b/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
@@ -19,6 +19,7 @@ import {
   type RtkUiStoreExtended,
 } from '../../utils/sync-with-store/ui-store';
 import deepMerge from 'lodash-es/merge';
+import { getInitErrorInfo } from '../../utils/init-error';
 import { PermissionSettings } from '../../types/props';
 
 const LEAVE_ROOM_TIMER = 10000;
@@ -68,16 +69,15 @@ export class RtkUiProvider {
    */
   @Event({ eventName: 'rtkStatesUpdate' }) statesUpdate: EventEmitter<States>;
 
-  private authErrorListener: (ev: CustomEvent<Error>) => void;
+  private initErrorListener: (ev: CustomEvent) => void;
 
   connectedCallback() {
     if (typeof window !== 'undefined') {
-      this.authErrorListener = (ev) => {
-        if (ev.detail.message.includes('401')) {
-          this.updateStates({ meeting: 'ended', roomLeftState: 'unauthorized' });
-        }
+      this.initErrorListener = (ev) => {
+        const { message, code } = getInitErrorInfo(this.t, ev.detail);
+        this.updateStates({ preJoinError: { message, code } });
       };
-      window.addEventListener('rtkError', this.authErrorListener);
+      window.addEventListener('ClientError', this.initErrorListener);
     }
 
     // Listen for store requests from child components
@@ -91,7 +91,7 @@ export class RtkUiProvider {
   }
 
   disconnectedCallback() {
-    window.removeEventListener('rtkError', this.authErrorListener);
+    window.removeEventListener('ClientError', this.initErrorListener);
 
     // Remove event listeners
     if (this.storeRequestListener) {
@@ -223,7 +223,7 @@ export class RtkUiProvider {
         }
       }
 
-      window.removeEventListener('rtkError', this.authErrorListener);
+      window.removeEventListener('ClientError', this.initErrorListener);
     }
   }
 

--- a/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
+++ b/packages/core/src/components/rtk-ui-provider/rtk-ui-provider.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../utils/sync-with-store/ui-store';
 import deepMerge from 'lodash-es/merge';
 import { getInitErrorInfo } from '../../utils/init-error';
+import { getJoinErrorInfo } from '../../utils/join-error';
 import { PermissionSettings } from '../../types/props';
 
 const LEAVE_ROOM_TIMER = 10000;
@@ -219,7 +220,15 @@ export class RtkUiProvider {
         if (this.showSetupScreen) {
           this.updateStates({ meeting: 'setup' });
         } else {
-          meeting.join();
+          meeting
+            .join()
+            .then(() => {
+              this.updateStates({ preJoinError: null });
+            })
+            .catch((err) => {
+              const { message, code } = getJoinErrorInfo(this.t, err);
+              this.updateStates({ preJoinError: { message, code } });
+            });
         }
       }
 
@@ -264,7 +273,7 @@ export class RtkUiProvider {
   }
 
   private roomJoinedListener = () => {
-    this.updateStates({ meeting: 'joined' });
+    this.updateStates({ meeting: 'joined', preJoinError: null });
   };
 
   private waitlistedListener = () => {

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -19,6 +19,7 @@ export { registerAddons, Addon } from './lib/addons';
 export { UIConfig } from './types/ui-config';
 export {
   States,
+  PreJoinError,
   Notification,
   Size,
   UserPreferences,

--- a/packages/core/src/lib/lang/default-language.ts
+++ b/packages/core/src/lib/lang/default-language.ts
@@ -296,6 +296,13 @@ export const defaultLanguage = {
   'network.lost_extended': 'Connection lost. Please check your network connection.',
   'network.troubleshoot': 'Troubleshoot your connection',
 
+  'init.auth_error':
+    "We couldn't verify your access to this meeting. The meeting may have ended, or you may not have permission to join.",
+  'init.network_error':
+    "We couldn't connect to the meeting. Please try again, and if the problem continues, check your internet connection.",
+  'init.browser_error': 'Your browser is not supported. Please try a different or updated browser.',
+  'init.default_error': 'Something went wrong while connecting to the meeting. Please try again.',
+
   'join.network_error':
     "We couldn't connect to the meeting. Please check your internet connection and try again.",
   'join.media_error':

--- a/packages/core/src/types/props.ts
+++ b/packages/core/src/types/props.ts
@@ -31,6 +31,17 @@ export interface PermissionSettings {
 }
 
 /**
+ * Error info for failures during the pre-join phase (init or join).
+ * Set by rtk-meeting / rtk-ui-provider, displayed by rtk-idle-screen.
+ */
+export interface PreJoinError {
+  /** Localized, user-friendly message suitable for display to end users. */
+  message: string;
+  /** Raw SDK error code (e.g. '0004'), displayed as a support reference. */
+  code?: string;
+}
+
+/**
  * Global States object which are shared among components
  */
 export interface States {
@@ -81,8 +92,7 @@ export interface States {
   prefs?: UserPreferences;
   sidebar?: RtkSidebarSection;
   roomLeftState?: RoomLeftState | 'unauthorized';
-  joinError?: string;
-  joinErrorCode?: string;
+  preJoinError?: PreJoinError | null;
   sidebarFloating?: boolean;
   participantsTabId?: ParticipantsTabId;
   [state: string]: any;

--- a/packages/core/src/utils/init-error.ts
+++ b/packages/core/src/utils/init-error.ts
@@ -1,0 +1,31 @@
+import type { RtkI18n } from '../lib/lang';
+import type { PreJoinError } from '../types/props';
+
+/**
+ * Maps a Core SDK init-phase error to a user-friendly message and support reference code.
+ *
+ * Called by the `initErrorListener` in `rtk-meeting` and `rtk-ui-provider` when a
+ * `ClientError` window event fires before the meeting object is available.
+ *
+ * Only handles error codes thrown by `Client.init()`:
+ *  - 0004 — Invalid auth token (401, 403, 404, malformed JWT)
+ *  - 0001 — Failed to initialize (network, timeout, server 5xx, catch-all)
+ *  - 0010 — Browser not supported (no RTCPeerConnection)
+ */
+export function getInitErrorInfo(t: RtkI18n, err: unknown): PreJoinError {
+  const code: string | undefined = (err as any)?.code;
+
+  switch (code) {
+    case '0004':
+      return { message: t('init.auth_error'), code };
+
+    case '0001':
+      return { message: t('init.network_error'), code };
+
+    case '0010':
+      return { message: t('init.browser_error'), code };
+
+    default:
+      return { message: t('init.default_error'), code };
+  }
+}


### PR DESCRIPTION
## Summary
This PR fixes init-phase error handling so users see error messages on the idle screen instead of an infinite spinner when `RealtimeKitClient.init()` fails. 

Also fixes unhandled `join()` rejection in rtk-ui-provider.

### Fixes
- Listen for 'ClientError' window events (the correct event name from the Core SDK)
- Handle all init error codes (0004 auth, 0001 network/server, 0010 browser not supported) with user-friendly messages on the idle screen
- Add `PreJoinError` type and preJoinError state in States, replacing the flat joinError/joinErrorCode fields
- Add `getInitErrorInfo()` utility mapping init error codes to i18n messages (follows `getJoinErrorInfo()` pattern)
- Add `.catch()` to `meeting.join()` in `rtk-ui-provider` matching the existing pattern in `rtk-meeting`
- Use `null` instead of undefined for clearing preJoinError via updateStates (lodash merge skips undefined)